### PR TITLE
fix(build): enable build of docker images

### DIFF
--- a/.github/workflows/credential-expiry-app-docker.yml
+++ b/.github/workflows/credential-expiry-app-docker.yml
@@ -17,7 +17,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-name: Credential Expiry App
+name: Build Credential Expiry App Image
 
 on: 
   push:

--- a/.github/workflows/migrations-docker.yml
+++ b/.github/workflows/migrations-docker.yml
@@ -17,7 +17,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-name: Migrations
+name: Build Migrations Image
 
 on: 
   push:

--- a/.github/workflows/migrations-docker.yml
+++ b/.github/workflows/migrations-docker.yml
@@ -74,7 +74,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: docker/Dockerfile-migrations
+          file: docker/Dockerfile-credential-issuer-migrations
           platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/processes-worker-docker.yml
+++ b/.github/workflows/processes-worker-docker.yml
@@ -17,7 +17,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-name: Processes Worker
+name: Build Processes Worker Image
 
 on:
   push:

--- a/.github/workflows/service-docker.yml
+++ b/.github/workflows/service-docker.yml
@@ -73,7 +73,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: docker/Dockerfile-service
+          file: docker/Dockerfile-credential-issuer-service
           platforms: linux/amd64, linux/arm64
           pull: true
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/service-docker.yml
+++ b/.github/workflows/service-docker.yml
@@ -17,7 +17,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-name: Service
+name: Build Service Image
 
 on:
   push:

--- a/docker/Dockerfile-credential-expiry-app
+++ b/docker/Dockerfile-credential-expiry-app
@@ -23,13 +23,13 @@ FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/
-RUN dotnet restore "src/credentials/SsiCredentialIssuer.Expiry.App/SsiCredentialIssuer.Expiry.csproj"
-WORKDIR /src/credentials/Credential.App
-RUN dotnet publish "SsiCredentialIssuer.Expiry.csproj" -c Release -o /app/publish
+RUN dotnet restore "src/credentials/SsiCredentialIssuer.Expiry.App/SsiCredentialIssuer.Expiry.App.csproj"
+WORKDIR /src/credentials/SsiCredentialIssuer.Expiry.App
+RUN dotnet publish "SsiCredentialIssuer.Expiry.App.csproj" -c Release -o /app/publish
 
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 RUN chown -R 1000:3000 /app
 USER 1000:3000
-ENTRYPOINT ["dotnet", "Org.Eclipse.TractusX.SsiCredentialIssuer.Credential.App.dll"]
+ENTRYPOINT ["dotnet", "Org.Eclipse.TractusX.SsiCredentialIssuer.Expiry.App.dll"]


### PR DESCRIPTION
## Description

- fix dockerfile for SsiCredentialIssuer.Expiry.App
- fix reference to dockerfile
- chore: rename image build workflows

## Why

#18
#20 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own changes
- [x] I have successfully tested my changes locally
