### PR TITLE
feat(helm): add paths for environment values

### DIFF
--- a/consortia/environments/values-beta.yaml
+++ b/consortia/environments/values-beta.yaml
@@ -41,6 +41,12 @@ issuer:
   swaggerEnabled: true
   credential: 
     issuerBpn: "BPNL00000003CRHK"
+    encryptionConfigs: 
+      index0: 
+        encryptionKey: "<path:portal/data/ssi-credential-issuer/beta/credential#encryptionKey0>"
+  portal:
+    clientId: "<path:portal/data/ssi-credential-issuer/portal#clientId>"
+    clientSecret: "<path:portal/data/ssi-credential-issuer/beta/portal#clientSecret>"
 
 issuermigrations:
   logging:
@@ -49,6 +55,15 @@ issuermigrations:
 processesworker:
   logging:
     default: "Debug"
+  portal:
+    clientId: "<path:portal/data/ssi-credential-issuer/portal#clientId>"
+    clientSecret: "<path:portal/data/ssi-credential-issuer/beta/portal#clientSecret>"
+  wallet:
+    clientId: "<path:portal/data/ssi-credential-issuer/beta/wallet#clientId>"
+    clientSecret: "<path:portal/data/ssi-credential-issuer/beta/wallet#clientSecret>"
+    encryptionConfigs:
+      index0:
+        encryptionKey: "<path:portal/data/ssi-credential-issuer/beta/wallet#encryptionKey0>"
 
 credentialexpiry:
   logging:

--- a/consortia/environments/values-dev.yaml
+++ b/consortia/environments/values-dev.yaml
@@ -44,6 +44,12 @@ issuer:
   swaggerEnabled: true
   credential:
     issuerBpn: "BPNL00000003CRHK"
+    encryptionConfigs:
+      index0:
+        encryptionKey: "<path:portal/data/ssi-credential-issuer/dev/credential#encryptionKey0>"
+  portal:
+    clientId: "<path:portal/data/ssi-credential-issuer/portal#clientId>"
+    clientSecret: "<path:portal/data/ssi-credential-issuer/dev/portal#clientSecret>"
 
 issuermigrations:
   image:
@@ -58,6 +64,15 @@ processesworker:
   imagePullPolicy: "Always"
   logging:
     default: "Debug"
+  portal:
+    clientId: "<path:portal/data/ssi-credential-issuer/portal#clientId>"
+    clientSecret: "<path:portal/data/ssi-credential-issuer/dev/portal#clientSecret>"
+  wallet:
+    clientId: "<path:portal/data/ssi-credential-issuer/dev/wallet#clientId>"
+    clientSecret: "<path:portal/data/ssi-credential-issuer/dev/wallet#clientSecret>"
+    encryptionConfigs:
+      index0:
+        encryptionKey: "<path:portal/data/ssi-credential-issuer/dev/wallet#encryptionKey0>"
 
 credentialexpiry:
   image:

--- a/consortia/environments/values-int.yaml
+++ b/consortia/environments/values-int.yaml
@@ -41,6 +41,12 @@ issuer:
   swaggerEnabled: true
   credential:
     issuerBpn: "BPNL00000003CRHK"
+    encryptionConfigs:
+      index0:
+        encryptionKey: "<path:portal/data/ssi-credential-issuer/int/credential#encryptionKey0>"
+  portal:
+    clientId: "<path:portal/data/ssi-credential-issuer/portal#clientId>"
+    clientSecret: "<path:portal/data/ssi-credential-issuer/int/portal#clientSecret>"
 
 issuermigrations:
   logging:
@@ -49,6 +55,15 @@ issuermigrations:
 processesworker:
   logging:
     default: "Debug"
+  portal:
+    clientId: "<path:portal/data/ssi-credential-issuer/portal#clientId>"
+    clientSecret: "<path:portal/data/ssi-credential-issuer/int/portal#clientSecret>"
+  wallet:
+    clientId: "<path:portal/data/ssi-credential-issuer/int/wallet#clientId>"
+    clientSecret: "<path:portal/data/ssi-credential-issuer/int/wallet#clientSecret>"
+    encryptionConfigs:
+      index0:
+        encryptionKey: "<path:portal/data/ssi-credential-issuer/int/wallet#encryptionKey0>"
 
 credentialexpiry:
   logging:

--- a/consortia/environments/values-pen.yaml
+++ b/consortia/environments/values-pen.yaml
@@ -41,6 +41,12 @@ issuer:
   swaggerEnabled: true
   credential:
     issuerBpn: "BPNL00000003CRHK"
+    encryptionConfigs:
+      index0:
+        encryptionKey: "<path:portal/data/ssi-credential-issuer/pen/credential#encryptionKey0>"
+  portal:
+    clientId: "<path:portal/data/ssi-credential-issuer/portal#clientId>"
+    clientSecret: "<path:portal/data/ssi-credential-issuer/pen/portal#clientSecret>"
 
 issuermigrations:
   logging:
@@ -49,6 +55,15 @@ issuermigrations:
 processesworker:
   logging:
     default: "Debug"
+  portal:
+    clientId: "<path:portal/data/ssi-credential-issuer/portal#clientId>"
+    clientSecret: "<path:portal/data/ssi-credential-issuer/pen/portal#clientSecret>"
+  wallet:
+    clientId: "<path:portal/data/ssi-credential-issuer/pen/wallet#clientId>"
+    clientSecret: "<path:portal/data/ssi-credential-issuer/pen/wallet#clientSecret>"
+    encryptionConfigs:
+      index0:
+        encryptionKey: "<path:portal/data/ssi-credential-issuer/pen/wallet#encryptionKey0>"
 
 credentialexpiry:
   logging:

--- a/consortia/environments/values-rc.yaml
+++ b/consortia/environments/values-rc.yaml
@@ -44,6 +44,12 @@ issuer:
   swaggerEnabled: true
   credential:
     issuerBpn: "BPNL00000003CRHK"
+    encryptionConfigs:
+      index0:
+        encryptionKey: "<path:portal/data/ssi-credential-issuer/dev/credential#encryptionKey0>"
+  portal:
+    clientId: "<path:portal/data/ssi-credential-issuer/portal#clientId>"
+    clientSecret: "<path:portal/data/ssi-credential-issuer/dev/portal#clientSecret>"
 
 issuermigrations:
   image:
@@ -58,6 +64,15 @@ processesworker:
   imagePullPolicy: "Always"
   logging:
     default: "Debug"
+  portal:
+    clientId: "<path:portal/data/ssi-credential-issuer/portal#clientId>"
+    clientSecret: "<path:portal/data/ssi-credential-issuer/dev/portal#clientSecret>"
+  wallet:
+    clientId: "<path:portal/data/ssi-credential-issuer/dev/wallet#clientId>"
+    clientSecret: "<path:portal/data/ssi-credential-issuer/dev/wallet#clientSecret>"
+    encryptionConfigs:
+      index0:
+        encryptionKey: "<path:portal/data/ssi-credential-issuer/dev/wallet#encryptionKey0>"
 
 credentialexpiry:
   image:


### PR DESCRIPTION
## Description

Added paths to environment specific configurations of clientIds and secrets

## Why

To have environment specific values for the clientIds and secrets

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
