### PR TITLE
fix: adjust the hosting url for rc and pen

### DIFF
--- a/consortia/environments/values-pen.yaml
+++ b/consortia/environments/values-pen.yaml
@@ -32,9 +32,9 @@ ingress:
   tls:
     - secretName: "tls-secret"
       hosts:
-        - "ssi-credential-issuer-backend-pen.dev.demo.catena-x.net"
+        - "ssi-credential-issuer-pen.dev.demo.catena-x.net"
   hosts:
-    - host: "ssi-credential-issuer-backend-pen.dev.demo.catena-x.net"
+    - host: "ssi-credential-issuer-pen.dev.demo.catena-x.net"
       paths:
         - path: "/api/issuer"
           pathType: "Prefix"

--- a/consortia/environments/values-rc.yaml
+++ b/consortia/environments/values-rc.yaml
@@ -32,9 +32,9 @@ ingress:
   tls:
     - secretName: "tls-secret"
       hosts:
-        - "ssi-credential-issuer-backend-rc.dev.demo.catena-x.net"
+        - "ssi-credential-issuer-rc.dev.demo.catena-x.net"
   hosts:
-    - host: "ssi-credential-issuer-backend-rc.dev.demo.catena-x.net"
+    - host: "ssi-credential-issuer-rc.dev.demo.catena-x.net"
       paths:
         - path: "/api/issuer"
           pathType: "Prefix"

--- a/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
@@ -516,6 +516,7 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
                 c.ClientId = technicalUserDetails.ClientId;
                 c.ClientSecret = secret;
                 c.InitializationVector = initializationVector;
+                c.EncryptionMode = _settings.EncrptionConfigIndex;
                 c.HolderWalletUrl = technicalUserDetails.WalletUrl;
                 c.CallbackUrl = callbackUrl;
             });


### PR DESCRIPTION
## Description

Adjusting the routing url, to remove the -backend of the subdomain

## Why

The SSI Credential Issuer will not have a frontend, therefore the subdomain prefix -backend isn't needed.

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
