### PR TITLE
fix: adjust bpn schema

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -6,7 +6,6 @@ nuget/nuget/-/EFCore.NamingConventions/7.0.2, Apache-2.0, approved, #10067
 nuget/nuget/-/FakeItEasy/7.4.0, MIT, approved, #10080
 nuget/nuget/-/Fare/2.1.1, MIT, approved, clearlydefined
 nuget/nuget/-/FluentAssertions/6.11.0, Apache-2.0 AND MIT, approved, #10061
-nuget/nuget/-/Flurl.Http.Signed/3.2.4, MIT, approved, #3503
 nuget/nuget/-/Flurl.Signed/3.0.6, MIT, approved, #3501
 nuget/nuget/-/Humanizer.Core/2.14.1, MIT, approved, #10060
 nuget/nuget/-/Json.More.Net/2.0.0, MIT, approved, clearlydefined

--- a/src/externalservices/Wallet.Service/Schemas/BPNCredential.schema.json
+++ b/src/externalservices/Wallet.Service/Schemas/BPNCredential.schema.json
@@ -58,11 +58,11 @@
         "bpn": {
           "type": "string"
         },
-        "holderIndentifier": {
+        "holderIdentifier": {
           "type": "string"
         }
       },
-      "required": ["id", "bpn", "holderIndentifier"]
+      "required": ["id", "bpn", "holderIdentifier"]
     }
   },
   "required": ["id", "@context", "type", "issuanceDate", "expirationDate", "issuer", "credentialSubject"]

--- a/tests/externalservices/Wallet.Service.Tests/BusinessLogic/WalletBusinessLogicTests.cs
+++ b/tests/externalservices/Wallet.Service.Tests/BusinessLogic/WalletBusinessLogicTests.cs
@@ -188,7 +188,7 @@ public class WalletBusinessLogicTests
                 "credentialSubject": {
                     "id": "did:web:example.org:api:administration:staticdata:did:BPNL000001PS0000",
                     "bpn": "BPNL000001PS0000",
-                    "holderIndentifier": "BPNL000001PS0000"
+                    "holderIdentifier": "BPNL000001PS0000"
                 }
             }
             """;


### PR DESCRIPTION
## Description

fixed typo in the bpn schema

## Why

The bpn schema has a typo in holderIdentifier

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
