### PR TITLE
fix(seeding): set consortia to seeding paths

### DIFF
--- a/consortia/environments/values-beta.yaml
+++ b/consortia/environments/values-beta.yaml
@@ -57,6 +57,8 @@ issuer:
 issuermigrations:
   logging:
     default: "Debug"
+  seeding:
+    testDataEnvironments: "consortia"
 
 processesworker:
   logging:

--- a/consortia/environments/values-dev.yaml
+++ b/consortia/environments/values-dev.yaml
@@ -63,6 +63,8 @@ issuermigrations:
   imagePullPolicy: "Always"
   logging:
     default: "Debug"
+  seeding:
+    testDataEnvironments: "consortia"
 
 processesworker:
   image:

--- a/consortia/environments/values-int.yaml
+++ b/consortia/environments/values-int.yaml
@@ -57,6 +57,8 @@ issuer:
 issuermigrations:
   logging:
     default: "Debug"
+  seeding:
+    testDataEnvironments: "consortia"
 
 processesworker:
   logging:

--- a/consortia/environments/values-pen.yaml
+++ b/consortia/environments/values-pen.yaml
@@ -57,6 +57,8 @@ issuer:
 issuermigrations:
   logging:
     default: "Debug"
+  seeding:
+    testDataEnvironments: "consortia"
 
 processesworker:
   logging:

--- a/consortia/environments/values-rc.yaml
+++ b/consortia/environments/values-rc.yaml
@@ -63,6 +63,8 @@ issuermigrations:
   imagePullPolicy: "Always"
   logging:
     default: "Debug"
+  seeding:
+    testDataEnvironments: "consortia"
 
 processesworker:
   image:

--- a/src/database/SsiCredentialIssuer.Migrations/Seeder/BatchUpdateSeeder.cs
+++ b/src/database/SsiCredentialIssuer.Migrations/Seeder/BatchUpdateSeeder.cs
@@ -63,12 +63,13 @@ public class BatchUpdateSeeder : ICustomSeeder
 
         await SeedTable<VerifiedCredentialExternalTypeDetailVersion>("verified_credential_external_type_detail_versions",
             x => x.Id,
-            x => x.dataEntity.Template != x.dbEntity.Template || x.dataEntity.Expiry != x.dbEntity.Expiry || x.dataEntity.ValidFrom != x.dbEntity.ValidFrom,
+            x => x.dataEntity.Template != x.dbEntity.Template || x.dataEntity.Expiry != x.dbEntity.Expiry || x.dataEntity.ValidFrom != x.dbEntity.ValidFrom || x.dataEntity.Version != x.dbEntity.Version,
             (dbEntry, entry) =>
             {
                 dbEntry.Template = entry.Template;
                 dbEntry.Expiry = entry.Expiry;
                 dbEntry.ValidFrom = entry.ValidFrom;
+                dbEntry.Version = entry.Version;
             }, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
 
         await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);

--- a/src/database/SsiCredentialIssuer.Migrations/Seeder/Data/verified_credential_external_type_detail_versions.consortia.json
+++ b/src/database/SsiCredentialIssuer.Migrations/Seeder/Data/verified_credential_external_type_detail_versions.consortia.json
@@ -19,15 +19,15 @@
     "id": "1268a76a-ca19-4dd8-b932-01f24071d562",
     "verified_credential_external_type_id": 3,
     "version": "1.0",
-    "template": null,
+    "template": "https://catena-x.net/fileadmin/user_upload/04_Einfuehren_und_umsetzen/Governance_Framework/231016_Catena-X_Use_Case_Framework_BehaviorTwin.pdf",
     "valid_from": "2023-06-01 00:00:00.000000 +00:00",
-    "expiry": "2023-09-30 00:00:00.000000 +00:00"
+    "expiry": "2024-12-31 00:00:00.000000 +00:00"
   },
   {
     "id": "1268a76a-ca19-4dd8-b932-01f24071d565",
     "verified_credential_external_type_id": 5,
     "version": "1.0",
-    "template": " https://catena-x.net/fileadmin/user_upload/04_Einfuehren_und_umsetzen/Governance_Framework/231016_Catena-X_Use_Case_Framework_CircularEconomy.pdf",
+    "template": "https://catena-x.net/fileadmin/user_upload/04_Einfuehren_und_umsetzen/Governance_Framework/231016_Catena-X_Use_Case_Framework_CircularEconomy.pdf",
     "valid_from": "2024-01-01 00:00:00.000000 +00:00",
     "expiry": "2024-12-31 00:00:00.000000 +00:00"
   }


### PR DESCRIPTION
## Description

* add consortia to the seeding paths to seed consortia related data

## Why

The seeding didn't seed consortia specific use cases, therefor some of them were missing

## Issue

Refs: #94 , #45

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
