### PR TITLE
fix(notification): adjust notification creation url

### DIFF
--- a/src/externalservices/Portal.Service/Services/PortalService.cs
+++ b/src/externalservices/Portal.Service/Services/PortalService.cs
@@ -44,7 +44,7 @@ public class PortalService : IPortalService
     {
         using var client = await _tokenService.GetAuthorizedClient<PortalService>(_settings, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
         var data = new NotificationRequest(requester, content, notificationTypeId);
-        await client.PostAsJsonAsync("api/notifications/ssi-credentials", data, Options, cancellationToken)
+        await client.PostAsJsonAsync("api/notification/ssi-credentials", data, Options, cancellationToken)
             .CatchingIntoServiceExceptionFor("notification", HttpAsyncResponseMessageExtension.RecoverOptions.REQUEST_EXCEPTION)
             .ConfigureAwait(false);
     }


### PR DESCRIPTION
## Description

adjust notification creation url

## Why

the call of the notification creation endpoint fails with a 404

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
