### PR TITLE
fix(notification): adjust enum serialization

### DIFF
--- a/tests/externalservices/Portal.Service.Tests/PortalServiceTests.cs
+++ b/tests/externalservices/Portal.Service.Tests/PortalServiceTests.cs
@@ -93,9 +93,9 @@ public class PortalServiceTests
     }
 
     [Theory]
-    [InlineData(HttpStatusCode.Conflict, "{ \"message\": \"Framework test!\" }", "call to external system notification failed with statuscode 409")]
-    [InlineData(HttpStatusCode.BadRequest, "{ \"test\": \"123\" }", "call to external system notification failed with statuscode 400")]
-    [InlineData(HttpStatusCode.BadRequest, "this is no json", "call to external system notification failed with statuscode 400")]
+    [InlineData(HttpStatusCode.Conflict, "{ \"message\": \"Framework test!\" }", "call to external system notification failed with statuscode 409 - Message: { \"message\": \"Framework test!\" }")]
+    [InlineData(HttpStatusCode.BadRequest, "{ \"test\": \"123\" }", "call to external system notification failed with statuscode 400 - Message: { \"test\": \"123\" }")]
+    [InlineData(HttpStatusCode.BadRequest, "this is no json", "call to external system notification failed with statuscode 400 - Message: this is no json")]
     [InlineData(HttpStatusCode.Forbidden, null, "call to external system notification failed with statuscode 403")]
     public async Task AddNotification_WithConflict_ThrowsServiceExceptionWithErrorContent(HttpStatusCode statusCode, string? content, string message)
     {


### PR DESCRIPTION
## Description

Adjust enum serialisation for notification creation

## Why

To send a correct request to the portal

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
