### PR TITLE
fix(approval): send mail and notification to requester

### DIFF
--- a/src/database/SsiCredentialIssuer.DbAccess/Models/SsiApprovalData.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Models/SsiApprovalData.cs
@@ -27,7 +27,8 @@ public record SsiApprovalData(
     VerifiedCredentialTypeId Type,
     Guid? ProcessId,
     VerifiedCredentialTypeKindId? Kind,
-    string? Bpn,
+    string Bpn,
+    string UserId,
     JsonDocument? Schema,
     DetailData? DetailData
 );

--- a/src/database/SsiCredentialIssuer.DbAccess/Repositories/CompanySsiDetailsRepository.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Repositories/CompanySsiDetailsRepository.cs
@@ -199,6 +199,7 @@ public class CompanySsiDetailsRepository : ICompanySsiDetailsRepository
                     x.ProcessId,
                     x.VerifiedCredentialType!.VerifiedCredentialTypeAssignedKind == null ? null : x.VerifiedCredentialType!.VerifiedCredentialTypeAssignedKind!.VerifiedCredentialTypeKindId,
                     x.Bpnl,
+                    x.CreatorUserId,
                     x.CompanySsiProcessData!.Schema,
                     x.VerifiedCredentialExternalTypeDetailVersion == null ?
                         null :
@@ -213,13 +214,14 @@ public class CompanySsiDetailsRepository : ICompanySsiDetailsRepository
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />
-    public Task<(bool Exists, CompanySsiDetailStatusId Status, VerifiedCredentialTypeId Type, Guid? ProcessId, IEnumerable<Guid> ProcessStepIds)> GetSsiRejectionData(Guid credentialId) =>
+    public Task<(bool Exists, CompanySsiDetailStatusId Status, VerifiedCredentialTypeId Type, string UserId, Guid? ProcessId, IEnumerable<Guid> ProcessStepIds)> GetSsiRejectionData(Guid credentialId) =>
         _context.CompanySsiDetails
             .Where(x => x.Id == credentialId)
-            .Select(x => new ValueTuple<bool, CompanySsiDetailStatusId, VerifiedCredentialTypeId, Guid?, IEnumerable<Guid>>(
+            .Select(x => new ValueTuple<bool, CompanySsiDetailStatusId, VerifiedCredentialTypeId, string, Guid?, IEnumerable<Guid>>(
                 true,
                 x.CompanySsiDetailStatusId,
                 x.VerifiedCredentialTypeId,
+                x.CreatorUserId,
                 x.ProcessId,
                 x.Process!.ProcessSteps.Where(ps => ps.ProcessStepStatusId == ProcessStepStatusId.TODO).Select(p => p.Id)
             ))

--- a/src/database/SsiCredentialIssuer.DbAccess/Repositories/ICompanySsiDetailsRepository.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Repositories/ICompanySsiDetailsRepository.cs
@@ -94,7 +94,7 @@ public interface ICompanySsiDetailsRepository
     IAsyncEnumerable<OwnedVerifiedCredentialData> GetOwnCredentialDetails(string bpnl);
 
     Task<(bool exists, SsiApprovalData data)> GetSsiApprovalData(Guid credentialId);
-    Task<(bool Exists, CompanySsiDetailStatusId Status, VerifiedCredentialTypeId Type, Guid? ProcessId, IEnumerable<Guid> ProcessStepIds)> GetSsiRejectionData(Guid credentialId);
+    Task<(bool Exists, CompanySsiDetailStatusId Status, VerifiedCredentialTypeId Type, string UserId, Guid? ProcessId, IEnumerable<Guid> ProcessStepIds)> GetSsiRejectionData(Guid credentialId);
     void AttachAndModifyCompanySsiDetails(Guid id, Action<CompanySsiDetail>? initialize, Action<CompanySsiDetail> updateFields);
     IAsyncEnumerable<VerifiedCredentialTypeId> GetCertificateTypes(string bpnl);
     IAsyncEnumerable<CredentialExpiryData> GetExpiryData(DateTimeOffset now, DateTimeOffset inactiveVcsToDelete, DateTimeOffset expiredVcsToDelete);

--- a/tests/issuer/SsiCredentialIssuer.Service.Tests/BusinessLogic/IssuerBusinessLogicTests.cs
+++ b/tests/issuer/SsiCredentialIssuer.Service.Tests/BusinessLogic/IssuerBusinessLogicTests.cs
@@ -45,6 +45,7 @@ public class IssuerBusinessLogicTests
     private static readonly Guid CredentialId = Guid.NewGuid();
     private static readonly string Bpnl = "BPNL00000001TEST";
     private static readonly string IssuerBpnl = "BPNL000001ISSUER";
+    private static readonly Guid CompanyUserId = Guid.NewGuid();
 
     private readonly IFixture _fixture;
     private readonly ICompanySsiDetailsRepository _companySsiDetailsRepository;
@@ -204,28 +205,6 @@ public class IssuerBusinessLogicTests
     }
 
     [Fact]
-    public async Task ApproveCredential_WithBpnNotSetActiveSsiDetail_ThrowsConflictException()
-    {
-        // Arrange
-        var alreadyActiveId = Guid.NewGuid();
-        var approvalData = _fixture.Build<SsiApprovalData>()
-            .With(x => x.Status, CompanySsiDetailStatusId.PENDING)
-            .With(x => x.Bpn, (string?)null)
-            .Create();
-        A.CallTo(() => _companySsiDetailsRepository.GetSsiApprovalData(alreadyActiveId))
-            .Returns((true, approvalData));
-        Task Act() => _sut.ApproveCredential(alreadyActiveId, CancellationToken.None);
-
-        // Act
-        var ex = await Assert.ThrowsAsync<UnexpectedConditionException>(Act);
-
-        // Assert
-        ex.Message.Should().Be(IssuerErrors.BPN_NOT_SET.ToString());
-        A.CallTo(() => _portalService.TriggerMail("CredentialApproval", A<Guid>._, A<IEnumerable<MailParameter>>._, A<CancellationToken>._)).MustNotHaveHappened();
-        A.CallTo(() => _issuerRepositories.SaveAsync()).MustNotHaveHappened();
-    }
-
-    [Fact]
     public async Task ApproveCredential_WithExpiryInThePast_ReturnsExpected()
     {
         // Arrange
@@ -245,6 +224,7 @@ public class IssuerBusinessLogicTests
             null,
             VerifiedCredentialTypeKindId.FRAMEWORK,
             Bpnl,
+            CompanyUserId.ToString(),
             JsonDocument.Parse(schema),
             detailData
         );
@@ -284,6 +264,7 @@ public class IssuerBusinessLogicTests
             null,
             VerifiedCredentialTypeKindId.FRAMEWORK,
             Bpnl,
+            CompanyUserId.ToString(),
             JsonDocument.Parse(schema),
             useCaseData
         );
@@ -311,6 +292,7 @@ public class IssuerBusinessLogicTests
             null,
             VerifiedCredentialTypeKindId.FRAMEWORK,
             Bpnl,
+            CompanyUserId.ToString(),
             null,
             null
         );
@@ -343,6 +325,7 @@ public class IssuerBusinessLogicTests
             Guid.NewGuid(),
             VerifiedCredentialTypeKindId.FRAMEWORK,
             Bpnl,
+            CompanyUserId.ToString(),
             null,
             new DetailData(
                 VerifiedCredentialExternalTypeId.TRACEABILITY_CREDENTIAL,
@@ -369,16 +352,15 @@ public class IssuerBusinessLogicTests
         ex.Message.Should().Be(IssuerErrors.ALREADY_LINKED_PROCESS.ToString());
     }
 
-    [Theory]
-    [InlineData(VerifiedCredentialTypeKindId.FRAMEWORK, VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK, VerifiedCredentialExternalTypeId.TRACEABILITY_CREDENTIAL)]
-    public async Task ApproveCredential_WithValid_ReturnsExpected(VerifiedCredentialTypeKindId kindId, VerifiedCredentialTypeId typeId, VerifiedCredentialExternalTypeId externalTypeId)
+    [Fact]
+    public async Task ApproveCredential_WithValid_ReturnsExpected()
     {
         // Arrange
         var schema = CreateSchema();
         var processData = new CompanySsiProcessData(CredentialId, JsonDocument.Parse(schema), VerifiedCredentialTypeKindId.FRAMEWORK);
         var now = DateTimeOffset.UtcNow;
         var detailData = new DetailData(
-            externalTypeId,
+            VerifiedCredentialExternalTypeId.TRACEABILITY_CREDENTIAL,
             "test",
             "1.0.0",
             DateTimeOffset.UtcNow
@@ -386,15 +368,16 @@ public class IssuerBusinessLogicTests
 
         var data = new SsiApprovalData(
             CompanySsiDetailStatusId.PENDING,
-            typeId,
+            VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK,
             null,
-            kindId,
+            VerifiedCredentialTypeKindId.FRAMEWORK,
             Bpnl,
+            CompanyUserId.ToString(),
             JsonDocument.Parse(schema),
             detailData
         );
 
-        var detail = new CompanySsiDetail(CredentialId, _identity.Bpnl, typeId, CompanySsiDetailStatusId.PENDING, "", Guid.NewGuid().ToString(), DateTimeOffset.Now);
+        var detail = new CompanySsiDetail(CredentialId, _identity.Bpnl, VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK, CompanySsiDetailStatusId.PENDING, "", Guid.NewGuid().ToString(), DateTimeOffset.Now);
         A.CallTo(() => _dateTimeProvider.OffsetNow).Returns(now);
         A.CallTo(() => _companySsiDetailsRepository.GetSsiApprovalData(CredentialId))
             .Returns((true, data));
@@ -417,6 +400,63 @@ public class IssuerBusinessLogicTests
         // Assert
         A.CallTo(() => _portalService.AddNotification(A<string>._, A<Guid>._, NotificationTypeId.CREDENTIAL_APPROVAL, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _portalService.TriggerMail("CredentialApproval", A<Guid>._, A<IEnumerable<MailParameter>>._, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _issuerRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _processStepRepository.CreateProcess(ProcessTypeId.CREATE_CREDENTIAL))
+            .MustHaveHappenedOnceExactly();
+
+        detail.CompanySsiDetailStatusId.Should().Be(CompanySsiDetailStatusId.ACTIVE);
+        detail.DateLastChanged.Should().Be(now);
+        processData.Schema.Deserialize<FrameworkCredential>()!.IssuanceDate.Should().Be(now);
+    }
+
+    [Fact]
+    public async Task ApproveCredential_WithValidWithoutCompanyUserRequester_DoesNotSendMailAndNotification()
+    {
+        // Arrange
+        var schema = CreateSchema();
+        var processData = new CompanySsiProcessData(CredentialId, JsonDocument.Parse(schema), VerifiedCredentialTypeKindId.FRAMEWORK);
+        var now = DateTimeOffset.UtcNow;
+        var detailData = new DetailData(
+            VerifiedCredentialExternalTypeId.TRACEABILITY_CREDENTIAL,
+            "test",
+            "1.0.0",
+            DateTimeOffset.UtcNow
+        );
+
+        var data = new SsiApprovalData(
+            CompanySsiDetailStatusId.PENDING,
+            VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK,
+            null,
+            VerifiedCredentialTypeKindId.FRAMEWORK,
+            Bpnl,
+            "test123",
+            JsonDocument.Parse(schema),
+            detailData
+        );
+
+        var detail = new CompanySsiDetail(CredentialId, _identity.Bpnl, VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK, CompanySsiDetailStatusId.PENDING, "", "test123", DateTimeOffset.Now);
+        A.CallTo(() => _dateTimeProvider.OffsetNow).Returns(now);
+        A.CallTo(() => _companySsiDetailsRepository.GetSsiApprovalData(CredentialId))
+            .Returns((true, data));
+        A.CallTo(() => _companySsiDetailsRepository.AttachAndModifyCompanySsiDetails(CredentialId, A<Action<CompanySsiDetail>?>._, A<Action<CompanySsiDetail>>._!))
+            .Invokes((Guid _, Action<CompanySsiDetail>? initialize, Action<CompanySsiDetail> updateFields) =>
+            {
+                initialize?.Invoke(detail);
+                updateFields.Invoke(detail);
+            });
+        A.CallTo(() => _companySsiDetailsRepository.AttachAndModifyProcessData(CredentialId, A<Action<CompanySsiProcessData>?>._, A<Action<CompanySsiProcessData>>._!))
+            .Invokes((Guid _, Action<CompanySsiProcessData>? initialize, Action<CompanySsiProcessData> updateFields) =>
+            {
+                initialize?.Invoke(processData);
+                updateFields.Invoke(processData);
+            });
+
+        // Act
+        await _sut.ApproveCredential(CredentialId, CancellationToken.None);
+
+        // Assert
+        A.CallTo(() => _portalService.AddNotification(A<string>._, A<Guid>._, NotificationTypeId.CREDENTIAL_APPROVAL, A<CancellationToken>._)).MustNotHaveHappened();
+        A.CallTo(() => _portalService.TriggerMail("CredentialApproval", A<Guid>._, A<IEnumerable<MailParameter>>._, A<CancellationToken>._)).MustNotHaveHappened();
         A.CallTo(() => _issuerRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
         A.CallTo(() => _processStepRepository.CreateProcess(ProcessTypeId.CREATE_CREDENTIAL))
             .MustHaveHappenedOnceExactly();
@@ -464,7 +504,7 @@ public class IssuerBusinessLogicTests
         // Arrange
         var notExistingId = Guid.NewGuid();
         A.CallTo(() => _companySsiDetailsRepository.GetSsiRejectionData(notExistingId))
-            .Returns(default((bool, CompanySsiDetailStatusId, VerifiedCredentialTypeId, Guid?, IEnumerable<Guid>)));
+            .Returns(default((bool, CompanySsiDetailStatusId, VerifiedCredentialTypeId, string, Guid?, IEnumerable<Guid>)));
         Task Act() => _sut.RejectCredential(notExistingId, CancellationToken.None);
 
         // Act
@@ -488,6 +528,7 @@ public class IssuerBusinessLogicTests
                 true,
                 status,
                 VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK,
+                CompanyUserId.ToString(),
                 null,
                 Enumerable.Empty<Guid>()
                 ));
@@ -514,6 +555,7 @@ public class IssuerBusinessLogicTests
                 true,
                 CompanySsiDetailStatusId.PENDING,
                 VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK,
+                CompanyUserId.ToString(),
                 null,
                 Enumerable.Empty<Guid>()));
         A.CallTo(() => _companySsiDetailsRepository.AttachAndModifyCompanySsiDetails(CredentialId, A<Action<CompanySsiDetail>?>._, A<Action<CompanySsiDetail>>._!))
@@ -547,6 +589,7 @@ public class IssuerBusinessLogicTests
                 true,
                 CompanySsiDetailStatusId.PENDING,
                 VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK,
+                CompanyUserId.ToString(),
                 Guid.NewGuid(),
                 Enumerable.Repeat<Guid>(Guid.NewGuid(), 1)));
         A.CallTo(() => _companySsiDetailsRepository.AttachAndModifyCompanySsiDetails(CredentialId, A<Action<CompanySsiDetail>?>._, A<Action<CompanySsiDetail>>._!))
@@ -562,6 +605,41 @@ public class IssuerBusinessLogicTests
         // Assert
         A.CallTo(() => _portalService.TriggerMail("CredentialRejected", A<Guid>._, A<IEnumerable<MailParameter>>._, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _portalService.AddNotification(A<string>._, A<Guid>._, NotificationTypeId.CREDENTIAL_REJECTED, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _issuerRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _processStepRepository.AttachAndModifyProcessSteps(A<IEnumerable<(Guid ProcessStepId, Action<ProcessStep>? Initialize, Action<ProcessStep> Modify)>>._)).MustHaveHappenedOnceExactly();
+
+        detail.CompanySsiDetailStatusId.Should().Be(CompanySsiDetailStatusId.INACTIVE);
+        detail.DateLastChanged.Should().Be(now);
+    }
+
+    [Fact]
+    public async Task RejectCredential_WithValidWithoutCompanyUserRequester_DoesNotSendMailAndNotification()
+    {
+        // Arrange
+        var now = DateTimeOffset.UtcNow;
+        var detail = new CompanySsiDetail(CredentialId, _identity.Bpnl, VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK, CompanySsiDetailStatusId.PENDING, IssuerBpnl, "test123", DateTimeOffset.Now);
+        A.CallTo(() => _dateTimeProvider.OffsetNow).Returns(now);
+        A.CallTo(() => _companySsiDetailsRepository.GetSsiRejectionData(CredentialId))
+            .Returns((
+                true,
+                CompanySsiDetailStatusId.PENDING,
+                VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK,
+                "test123",
+                Guid.NewGuid(),
+                Enumerable.Repeat(Guid.NewGuid(), 1)));
+        A.CallTo(() => _companySsiDetailsRepository.AttachAndModifyCompanySsiDetails(CredentialId, A<Action<CompanySsiDetail>?>._, A<Action<CompanySsiDetail>>._!))
+            .Invokes((Guid _, Action<CompanySsiDetail>? initialize, Action<CompanySsiDetail> updateFields) =>
+            {
+                initialize?.Invoke(detail);
+                updateFields.Invoke(detail);
+            });
+
+        // Act
+        await _sut.RejectCredential(CredentialId, CancellationToken.None);
+
+        // Assert
+        A.CallTo(() => _portalService.TriggerMail(A<string>._, A<Guid>._, A<IEnumerable<MailParameter>>._, A<CancellationToken>._)).MustNotHaveHappened();
+        A.CallTo(() => _portalService.AddNotification(A<string>._, A<Guid>._, A<NotificationTypeId>._, A<CancellationToken>._)).MustNotHaveHappened();
         A.CallTo(() => _issuerRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
         A.CallTo(() => _processStepRepository.AttachAndModifyProcessSteps(A<IEnumerable<(Guid ProcessStepId, Action<ProcessStep>? Initialize, Action<ProcessStep> Modify)>>._)).MustHaveHappenedOnceExactly();
 


### PR DESCRIPTION
## Description

Adjust the mail and notification creation to create them for the requesting user instead of the calling user.

## Why

Since the calling user is the operator, the requesting user is currently not informed about the approval / rejection of the credentials.

## Issue

Refs: https://github.com/eclipse-tractusx/portal-backend/issues/712

## Corresponding Portal PR

[713](https://github.com/eclipse-tractusx/portal-backend/pull/713)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
