### PR TITLE
fix(credential): remove duplicate credential

### DIFF
--- a/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
@@ -463,8 +463,8 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
         var schemaData = new FrameworkCredential(
             Guid.NewGuid(),
             Context,
-            new[] { "VerifiableCredential", $"{externalTypeId}Credential" },
-            $"{externalTypeId}Credential",
+            new[] { "VerifiableCredential", externalTypeId },
+            externalTypeId,
             $"Framework Credential for UseCase {externalTypeId}",
             DateTimeOffset.UtcNow,
             result.Expiry,


### PR DESCRIPTION
## Description

Remove duplicate credential from credential name of framework credentials

## Why

The duplicate Credential is resulting in an error for the communication of the edc.

## Issue

Refs: TEST-1997

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
