### PR TITLE
feat(issuer): add filter to /api/issuer

### DIFF
--- a/src/database/SsiCredentialIssuer.DbAccess/Models/CompanySsiApprovalType.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Models/CompanySsiApprovalType.cs
@@ -17,12 +17,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using System.Text.Json;
+using Org.Eclipse.TractusX.SsiCredentialIssuer.Entities.Entities;
 
-namespace Org.Eclipse.TractusX.SsiCredentialIssuer.Service.BusinessLogic;
+namespace Org.Eclipse.TractusX.SsiCredentialIssuer.DBAccess.Models;
 
-public interface ICredentialBusinessLogic
+/// <summary>
+/// Possible filter options for the <see cref="CompanySsiDetail"/> pagination
+/// </summary>
+public enum CompanySsiDetailApprovalType
 {
-    Task<JsonDocument> GetCredentialDocument(Guid credentialId);
-    Task<(string FileName, byte[] Content, string MediaType)> GetCredentialDocumentById(Guid documentId);
+    /// <summary>
+    /// The credential request will be automatically approved
+    /// </summary>
+    Automatic = 1,
+
+    /// <summary>
+    /// The operator needs to approve the credential request
+    /// </summary>
+    Manual = 2,
 }

--- a/src/database/SsiCredentialIssuer.DbAccess/Repositories/CompanySsiDetailsRepository.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Repositories/CompanySsiDetailsRepository.cs
@@ -169,11 +169,12 @@ public class CompanySsiDetailsRepository : ICompanySsiDetailsRepository
             .SingleOrDefaultAsync();
 
     /// <inheritdoc />
-    public IQueryable<CompanySsiDetail> GetAllCredentialDetails(CompanySsiDetailStatusId? companySsiDetailStatusId, VerifiedCredentialTypeId? credentialTypeId) =>
+    public IQueryable<CompanySsiDetail> GetAllCredentialDetails(CompanySsiDetailStatusId? companySsiDetailStatusId, VerifiedCredentialTypeId? credentialTypeId, CompanySsiDetailApprovalType? approvalType) =>
         _context.CompanySsiDetails.AsNoTracking()
             .Where(c =>
                 (!companySsiDetailStatusId.HasValue || c.CompanySsiDetailStatusId == companySsiDetailStatusId.Value) &&
-                (!credentialTypeId.HasValue || c.VerifiedCredentialTypeId == credentialTypeId));
+                (!credentialTypeId.HasValue || c.VerifiedCredentialTypeId == credentialTypeId) &&
+                (!approvalType.HasValue || (approvalType.Value == CompanySsiDetailApprovalType.Automatic && c.VerifiedCredentialType!.VerifiedCredentialTypeAssignedKind!.VerifiedCredentialTypeKindId == VerifiedCredentialTypeKindId.FRAMEWORK) || (approvalType.Value == CompanySsiDetailApprovalType.Manual && c.VerifiedCredentialType!.VerifiedCredentialTypeAssignedKind!.VerifiedCredentialTypeKindId != VerifiedCredentialTypeKindId.FRAMEWORK)));
 
     /// <inheritdoc />
     public IAsyncEnumerable<OwnedVerifiedCredentialData> GetOwnCredentialDetails(string bpnl) =>

--- a/src/database/SsiCredentialIssuer.DbAccess/Repositories/CredentialRepository.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Repositories/CredentialRepository.cs
@@ -26,22 +26,15 @@ using System.Text.Json;
 
 namespace Org.Eclipse.TractusX.SsiCredentialIssuer.DBAccess.Repositories;
 
-public class CredentialRepository : ICredentialRepository
+public class CredentialRepository(IssuerDbContext dbContext) : ICredentialRepository
 {
-    private readonly IssuerDbContext _dbContext;
-
-    public CredentialRepository(IssuerDbContext dbContext)
-    {
-        _dbContext = dbContext;
-    }
-
     public Task<Guid?> GetWalletCredentialId(Guid credentialId) =>
-        _dbContext.CompanySsiDetails.Where(x => x.Id == credentialId)
+        dbContext.CompanySsiDetails.Where(x => x.Id == credentialId)
             .Select(x => x.ExternalCredentialId)
             .SingleOrDefaultAsync();
 
     public Task<(HolderWalletData HolderWalletData, string? Credential, EncryptionTransformationData EncryptionInformation, string? CallbackUrl)> GetCredentialData(Guid credentialId) =>
-        _dbContext.CompanySsiDetails
+        dbContext.CompanySsiDetails
             .Where(x => x.Id == credentialId)
             .Select(x => new ValueTuple<HolderWalletData, string?, EncryptionTransformationData, string?>(
                 new HolderWalletData(x.CompanySsiProcessData!.HolderWalletUrl, x.CompanySsiProcessData.ClientId),
@@ -51,19 +44,19 @@ public class CredentialRepository : ICredentialRepository
             .SingleOrDefaultAsync();
 
     public Task<(bool Exists, Guid CredentialId)> GetDataForProcessId(Guid processId) =>
-        _dbContext.CompanySsiDetails
+        dbContext.CompanySsiDetails
             .Where(c => c.ProcessId == processId)
             .Select(c => new ValueTuple<bool, Guid>(true, c.Id))
             .SingleOrDefaultAsync();
 
     public Task<(VerifiedCredentialTypeKindId CredentialTypeKindId, JsonDocument Schema)> GetCredentialStorageInformationById(Guid credentialId) =>
-        _dbContext.CompanySsiDetails
+        dbContext.CompanySsiDetails
             .Where(c => c.Id == credentialId)
             .Select(c => new ValueTuple<VerifiedCredentialTypeKindId, JsonDocument>(c.CompanySsiProcessData!.CredentialTypeKindId, c.CompanySsiProcessData.Schema))
             .SingleOrDefaultAsync();
 
     public Task<(Guid? ExternalCredentialId, VerifiedCredentialTypeKindId KindId, bool HasEncryptionInformation, string? CallbackUrl)> GetExternalCredentialAndKindId(Guid credentialId) =>
-        _dbContext.CompanySsiDetails
+        dbContext.CompanySsiDetails
             .Where(c => c.Id == credentialId)
             .Select(c => new ValueTuple<Guid?, VerifiedCredentialTypeKindId, bool, string?>(
                 c.ExternalCredentialId,
@@ -73,13 +66,13 @@ public class CredentialRepository : ICredentialRepository
             .SingleOrDefaultAsync();
 
     public Task<(string Bpn, string? CallbackUrl)> GetCallbackUrl(Guid credentialId) =>
-        _dbContext.CompanySsiProcessData
+        dbContext.CompanySsiProcessData
             .Where(x => x.CompanySsiDetailId == credentialId)
             .Select(x => new ValueTuple<string, string?>(x.CompanySsiDetail!.Bpnl, x.CallbackUrl))
             .SingleOrDefaultAsync();
 
     public Task<(bool Exists, bool IsSameBpnl, Guid? ExternalCredentialId, CompanySsiDetailStatusId StatusId, IEnumerable<(Guid DocumentId, DocumentStatusId DocumentStatusId)> Documents)> GetRevocationDataById(Guid credentialId, string bpnl) =>
-        _dbContext.CompanySsiDetails
+        dbContext.CompanySsiDetails
             .Where(x =>
                 x.Id == credentialId)
             .Select(x => new ValueTuple<bool, bool, Guid?, CompanySsiDetailStatusId, IEnumerable<(Guid, DocumentStatusId)>>(
@@ -94,22 +87,34 @@ public class CredentialRepository : ICredentialRepository
     {
         var entity = new CompanySsiDetail(credentialId, string.Empty, default!, default!, null!, null!, default!);
         initialize?.Invoke(entity);
-        _dbContext.CompanySsiDetails.Attach(entity);
+        dbContext.CompanySsiDetails.Attach(entity);
         modify(entity);
     }
 
     public Task<(VerifiedCredentialTypeId TypeId, string RequesterId)> GetCredentialNotificationData(Guid credentialId) =>
-        _dbContext.CompanySsiDetails
+        dbContext.CompanySsiDetails
             .Where(x => x.Id == credentialId)
             .Select(x => new ValueTuple<VerifiedCredentialTypeId, string>(x.VerifiedCredentialTypeId, x.CreatorUserId))
             .SingleOrDefaultAsync();
 
     public Task<(bool Exists, bool IsSameCompany, IEnumerable<(DocumentStatusId StatusId, byte[] Content)> Documents)> GetSignedCredentialForCredentialId(Guid credentialId, string bpnl) =>
-        _dbContext.CompanySsiDetails
+        dbContext.CompanySsiDetails
             .Where(x => x.Id == credentialId)
             .Select(x => new ValueTuple<bool, bool, IEnumerable<ValueTuple<DocumentStatusId, byte[]>>>(
                 true,
                 x.Bpnl == bpnl,
                 x.Documents.Where(d => d.DocumentTypeId == DocumentTypeId.VERIFIED_CREDENTIAL).Select(d => new ValueTuple<DocumentStatusId, byte[]>(d.DocumentStatusId, d.DocumentContent))))
+            .SingleOrDefaultAsync();
+
+    public Task<(bool Exists, bool IsSameCompany, string FileName, DocumentStatusId StatusId, byte[] Content, MediaTypeId MediaTypeId)> GetDocumentById(Guid documentId, string bpnl) =>
+        dbContext.Documents
+            .Where(x => x.Id == documentId)
+            .Select(x => new ValueTuple<bool, bool, string, DocumentStatusId, byte[], MediaTypeId>(
+                true,
+                x.CompanySsiDetails.Any(c => c.Bpnl == bpnl),
+                x.DocumentName,
+                x.DocumentStatusId,
+                x.DocumentContent,
+                x.MediaTypeId))
             .SingleOrDefaultAsync();
 }

--- a/src/database/SsiCredentialIssuer.DbAccess/Repositories/ICompanySsiDetailsRepository.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Repositories/ICompanySsiDetailsRepository.cs
@@ -85,8 +85,9 @@ public interface ICompanySsiDetailsRepository
     /// </summary>
     /// <param name="companySsiDetailStatusId">The status of the details</param>
     /// <param name="credentialTypeId">OPTIONAL: The type of the credential that should be returned</param>
+    /// <param name="approvalType">OPTIONAL: The approval type of the credential</param>
     /// <returns>Returns data to create the pagination</returns>
-    IQueryable<CompanySsiDetail> GetAllCredentialDetails(CompanySsiDetailStatusId? companySsiDetailStatusId, VerifiedCredentialTypeId? credentialTypeId);
+    IQueryable<CompanySsiDetail> GetAllCredentialDetails(CompanySsiDetailStatusId? companySsiDetailStatusId, VerifiedCredentialTypeId? credentialTypeId, CompanySsiDetailApprovalType? approvalType);
 
     /// <summary>
     /// Gets all credentials for a specific bpn

--- a/src/database/SsiCredentialIssuer.DbAccess/Repositories/ICredentialRepository.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Repositories/ICredentialRepository.cs
@@ -36,4 +36,5 @@ public interface ICredentialRepository
     void AttachAndModifyCredential(Guid credentialId, Action<CompanySsiDetail>? initialize, Action<CompanySsiDetail> modify);
     Task<(VerifiedCredentialTypeId TypeId, string RequesterId)> GetCredentialNotificationData(Guid credentialId);
     Task<(bool Exists, bool IsSameCompany, IEnumerable<(DocumentStatusId StatusId, byte[] Content)> Documents)> GetSignedCredentialForCredentialId(Guid credentialId, string bpnl);
+    Task<(bool Exists, bool IsSameCompany, string FileName, DocumentStatusId StatusId, byte[] Content, MediaTypeId MediaTypeId)> GetDocumentById(Guid documentId, string bpnl);
 }

--- a/src/database/SsiCredentialIssuer.Migrations/Seeder/BatchInsertSeeder.cs
+++ b/src/database/SsiCredentialIssuer.Migrations/Seeder/BatchInsertSeeder.cs
@@ -63,6 +63,7 @@ public class BatchInsertSeeder : ICustomSeeder
         _logger.LogInformation("Start BaseEntityBatch Seeder");
         await SeedBaseEntity(cancellationToken);
         await SeedTable<CompanySsiProcessData>("company_ssi_process_datas", x => x.CompanySsiDetailId, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        await SeedTable<CompanySsiDetailAssignedDocument>("company_ssi_detail_assigned_documents", x => new { x.DocumentId, x.CompanySsiDetailId }, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
         await SeedTable<VerifiedCredentialTypeAssignedKind>("verified_credential_type_assigned_kinds", x => new { x.VerifiedCredentialTypeId, x.VerifiedCredentialTypeKindId }, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
         await SeedTable<VerifiedCredentialTypeAssignedUseCase>("verified_credential_type_assigned_use_cases", x => new { x.VerifiedCredentialTypeId, x.UseCaseId }, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
         await SeedTable<VerifiedCredentialTypeAssignedExternalType>("verified_credential_type_assigned_external_types", x => new { x.VerifiedCredentialTypeId, x.VerifiedCredentialExternalTypeId }, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);

--- a/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IIssuerBusinessLogic.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IIssuerBusinessLogic.cs
@@ -30,7 +30,7 @@ public interface IIssuerBusinessLogic
 
     IAsyncEnumerable<CertificateParticipationData> GetSsiCertificatesAsync();
 
-    Task<Pagination.Response<CredentialDetailData>> GetCredentials(int page, int size, CompanySsiDetailStatusId? companySsiDetailStatusId, VerifiedCredentialTypeId? credentialTypeId, CompanySsiDetailSorting? sorting);
+    Task<Pagination.Response<CredentialDetailData>> GetCredentials(int page, int size, CompanySsiDetailStatusId? companySsiDetailStatusId, VerifiedCredentialTypeId? credentialTypeId, CompanySsiDetailApprovalType? approvalType, CompanySsiDetailSorting? sorting);
     IAsyncEnumerable<OwnedVerifiedCredentialData> GetCredentialsForBpn();
 
     Task ApproveCredential(Guid credentialId, CancellationToken cancellationToken);

--- a/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
@@ -96,11 +96,11 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
             .GetSsiCertificates(_identity.Bpnl, _dateTimeProvider.OffsetNow);
 
     /// <inheritdoc />
-    public Task<Pagination.Response<CredentialDetailData>> GetCredentials(int page, int size, CompanySsiDetailStatusId? companySsiDetailStatusId, VerifiedCredentialTypeId? credentialTypeId, CompanySsiDetailSorting? sorting)
+    public Task<Pagination.Response<CredentialDetailData>> GetCredentials(int page, int size, CompanySsiDetailStatusId? companySsiDetailStatusId, VerifiedCredentialTypeId? credentialTypeId, CompanySsiDetailApprovalType? approvalType, CompanySsiDetailSorting? sorting)
     {
         var query = _repositories
             .GetInstance<ICompanySsiDetailsRepository>()
-            .GetAllCredentialDetails(companySsiDetailStatusId, credentialTypeId);
+            .GetAllCredentialDetails(companySsiDetailStatusId, credentialTypeId, approvalType);
         var sortedQuery = sorting switch
         {
             CompanySsiDetailSorting.BpnlAsc or null => query.OrderBy(c => c.Bpnl),

--- a/src/issuer/SsiCredentialIssuer.Service/Controllers/IssuerController.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/Controllers/IssuerController.cs
@@ -80,8 +80,9 @@ public static class IssuerController
                 [FromQuery] int? size,
                 [FromQuery] CompanySsiDetailStatusId? companySsiDetailStatusId,
                 [FromQuery] VerifiedCredentialTypeId? credentialTypeId,
+                [FromQuery] CompanySsiDetailApprovalType? approvalType,
                 [FromQuery] CompanySsiDetailSorting? sorting) => logic.GetCredentials(page ?? 0, size ?? 15,
-                companySsiDetailStatusId, credentialTypeId, sorting))
+                companySsiDetailStatusId, credentialTypeId, approvalType, sorting))
             .WithSwaggerDescription("Gets all outstanding, existing and inactive credentials",
                 "Example: GET: /api/issuer",
                 "The page to get",

--- a/src/issuer/SsiCredentialIssuer.Service/ErrorHandling/CredentialErrorMessageContainer.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/ErrorHandling/CredentialErrorMessageContainer.cs
@@ -59,7 +59,10 @@ public class CredentialErrorMessageContainer : IErrorMessageContainer
         { CredentialErrors.SCHEMA_NOT_FRAMEWORK, "The schema must be a framework credential" },
         { CredentialErrors.CREDENTIAL_NOT_FOUND, "Credential {credentialId} does not exist" },
         { CredentialErrors.COMPANY_NOT_ALLOWED, "Not allowed to display the credential" },
-        { CredentialErrors.SIGNED_CREDENTIAL_NOT_FOUND, "There must be exactly one signed credential" }
+        { CredentialErrors.SIGNED_CREDENTIAL_NOT_FOUND, "There must be exactly one signed credential" },
+        { CredentialErrors.DOCUMENT_NOT_FOUND, "Document {documentId} does not exist" },
+        { CredentialErrors.DOCUMENT_INACTIVE, "Document {documentId} is inactive" },
+        { CredentialErrors.DOCUMENT_OTHER_COMPANY, "Not allowed to access document of another company" }
     }.ToImmutableDictionary(x => (int)x.Key, x => x.Value);
 
     public Type Type { get => typeof(CredentialErrors); }
@@ -100,5 +103,8 @@ public enum CredentialErrors
     SCHEMA_NOT_FRAMEWORK,
     CREDENTIAL_NOT_FOUND,
     COMPANY_NOT_ALLOWED,
-    SIGNED_CREDENTIAL_NOT_FOUND
+    SIGNED_CREDENTIAL_NOT_FOUND,
+    DOCUMENT_NOT_FOUND,
+    DOCUMENT_INACTIVE,
+    DOCUMENT_OTHER_COMPANY
 }

--- a/src/issuer/SsiCredentialIssuer.Service/Identity/MandatoryIdentityClaimHandler.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/Identity/MandatoryIdentityClaimHandler.cs
@@ -92,11 +92,12 @@ public class MandatoryIdentityClaimHandler : AuthorizationHandler<MandatoryIdent
         }
 
         _identityDataBuilder.AddIdentityId(preferredUserName ?? clientId!);
-        bool isCompanyUser;
-        if (isCompanyUser = Guid.TryParse(preferredUserName, out var companyUserId))
+        var isCompanyUser = Guid.TryParse(preferredUserName, out var companyUserId);
+        if (isCompanyUser)
         {
             _identityDataBuilder.AddCompanyUserId(companyUserId);
         }
+
         _identityDataBuilder.AddIsServiceAccount(!isCompanyUser);
         _identityDataBuilder.Status = IClaimsIdentityDataBuilderStatus.Complete;
     }

--- a/tests/database/SsiCredentialIssuer.DbAccess.Tests/CompanySsiDetailsRepositoryTests.cs
+++ b/tests/database/SsiCredentialIssuer.DbAccess.Tests/CompanySsiDetailsRepositoryTests.cs
@@ -113,7 +113,7 @@ public class CompanySsiDetailsRepositoryTests
         var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetAllCredentialDetails(null, null).ToListAsync();
+        var result = await sut.GetAllCredentialDetails(null, null, null).ToListAsync();
 
         // Assert
         result.Should().NotBeNull();
@@ -138,7 +138,7 @@ public class CompanySsiDetailsRepositoryTests
         var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetAllCredentialDetails(CompanySsiDetailStatusId.PENDING, null).ToListAsync();
+        var result = await sut.GetAllCredentialDetails(CompanySsiDetailStatusId.PENDING, null, null).ToListAsync();
 
         // Assert
         result.Should().NotBeNull().And.HaveCount(4);
@@ -159,7 +159,7 @@ public class CompanySsiDetailsRepositoryTests
         var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetAllCredentialDetails(null, VerifiedCredentialTypeId.PCF_FRAMEWORK).ToListAsync();
+        var result = await sut.GetAllCredentialDetails(null, VerifiedCredentialTypeId.PCF_FRAMEWORK, null).ToListAsync();
 
         // Assert
         result.Should().NotBeNull().And.ContainSingle().Which.Bpnl.Should().Be(ValidBpnl);

--- a/tests/database/SsiCredentialIssuer.DbAccess.Tests/Seeder/Data/company_ssi_detail_assigned_documents.test.json
+++ b/tests/database/SsiCredentialIssuer.DbAccess.Tests/Seeder/Data/company_ssi_detail_assigned_documents.test.json
@@ -1,0 +1,6 @@
+[
+  {
+    "document_id": "e020787d-1e04-4c0b-9c06-bd1cd44724b1",
+    "company_ssi_detail_id": "9f5b9934-4014-4099-91e9-7b1aee696b03"
+  }
+]

--- a/tests/database/SsiCredentialIssuer.DbAccess.Tests/Seeder/Data/company_ssi_process_datas.test.json
+++ b/tests/database/SsiCredentialIssuer.DbAccess.Tests/Seeder/Data/company_ssi_process_datas.test.json
@@ -7,6 +7,7 @@
     "credential_type_kind_id": 1,
     "encryption_mode": 1,
     "holder_wallet_url": "https://example.org/wallet",
-    "client_id": "c123"
+    "client_id": "c123",
+    "callback_url": "https://example.org/callback"
   }
 ]

--- a/tests/issuer/SsiCredentialIssuer.Service.Tests/Controllers/IssuerControllerTests.cs
+++ b/tests/issuer/SsiCredentialIssuer.Service.Tests/Controllers/IssuerControllerTests.cs
@@ -26,7 +26,7 @@ using System.Text.Json.Serialization;
 
 namespace Org.Eclipse.TractusX.SsiCredentialIssuer.Service.Tests.Controllers;
 
-public class IssuerControllerTests : IClassFixture<IntegrationTestFactory>
+public class IssuerControllerTests(IntegrationTestFactory factory) : IClassFixture<IntegrationTestFactory>
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -36,12 +36,7 @@ public class IssuerControllerTests : IClassFixture<IntegrationTestFactory>
     };
 
     private const string BaseUrl = "/api/issuer";
-    private readonly HttpClient _client;
-
-    public IssuerControllerTests(IntegrationTestFactory factory)
-    {
-        _client = factory.CreateClient();
-    }
+    private readonly HttpClient _client = factory.CreateClient();
 
     #region GetCertificateTypes
 


### PR DESCRIPTION

## Description

* add optional filter for approval type to endpoitn GET /api/issuer
* add Get document endpoint

## Why

To give the customer the possibility to filter for credentials that need approval and won't be automatically approved.

## Issue

Refs: #111 #27

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
