### PR TITLE
fix(credential): adjust puris credential naming

### DIFF
--- a/src/database/SsiCredentialIssuer.Entities/Enums/VerifiedCredentialExternalTypeId.cs
+++ b/src/database/SsiCredentialIssuer.Entities/Enums/VerifiedCredentialExternalTypeId.cs
@@ -47,7 +47,7 @@ public enum VerifiedCredentialExternalTypeId
     [EnumMember(Value = "DemandCapacityCredential")]
     DEMAND_AND_CAPACITY_MANAGEMENT = 8,
 
-    [EnumMember(Value = "DemandCapacityCredential")]
+    [EnumMember(Value = "PurisCredential")]
     DEMAND_AND_CAPACITY_MANAGEMENT_PURIS = 9,
 
     [EnumMember(Value = "BusinessPartnerCredential")]

--- a/src/issuer/SsiCredentialIssuer.Service/Controllers/RevocationController.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/Controllers/RevocationController.cs
@@ -48,10 +48,9 @@ public static class RevocationController
             .WithDefaultResponses()
             .Produces(StatusCodes.Status200OK, typeof(Guid));
         revocation.MapPost("credentials/{credentialId}", ([FromRoute] Guid credentialId, CancellationToken cancellationToken, [FromServices] IRevocationBusinessLogic logic) => logic.RevokeCredential(credentialId, false, cancellationToken))
-            .WithSwaggerDescription("Revokes an credential of an holder",
+            .WithSwaggerDescription("Credential Revocation by holder",
                 "POST: api/revocation/credentials/{credentialId}",
                 "Id of the credential that should be revoked",
-                "The information for the holder wallet",
                 "CancellationToken")
             .RequireAuthorization(r =>
             {


### PR DESCRIPTION
## Description

Instead of sending the DemandCapacityCredential the correct value PurisCredential is send.

## Why

Currently the wrong value is send to create the PurisCredential

## Issue

Refs: #147

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
