### PR TITLE
fix(ownedCredential): add credential id to response

### DIFF
--- a/src/database/SsiCredentialIssuer.DbAccess/Models/OwnedVerifiedCredentialData.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Models/OwnedVerifiedCredentialData.cs
@@ -22,6 +22,7 @@ using Org.Eclipse.TractusX.SsiCredentialIssuer.Entities.Enums;
 namespace Org.Eclipse.TractusX.SsiCredentialIssuer.DBAccess.Models;
 
 public record OwnedVerifiedCredentialData(
+    Guid CredentialDetailId,
     VerifiedCredentialTypeId CredentialType,
     CompanySsiDetailStatusId Status,
     DateTimeOffset? ExpiryDate,

--- a/src/database/SsiCredentialIssuer.DbAccess/Repositories/CompanySsiDetailsRepository.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Repositories/CompanySsiDetailsRepository.cs
@@ -180,6 +180,7 @@ public class CompanySsiDetailsRepository : ICompanySsiDetailsRepository
         _context.CompanySsiDetails.AsNoTracking()
             .Where(c => c.Bpnl == bpnl)
             .Select(c => new OwnedVerifiedCredentialData(
+                c.Id,
                 c.VerifiedCredentialTypeId,
                 c.CompanySsiDetailStatusId,
                 c.ExpiryDate,


### PR DESCRIPTION
## Description

Added the credential detail id to the response of the owned-credential endpoint

## Why

To revoke the credentials the id is needed, since the endpoint does not return the id it is added with this pr.

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
