### PR TITLE
fix(ingress): adjust api path

### DIFF
--- a/charts/ssi-credential-issuer/values.yaml
+++ b/charts/ssi-credential-issuer/values.yaml
@@ -260,7 +260,7 @@ ingress:
     # -- Provide default path for the ingress record.
     - host: ""
       paths:
-        - path: "/api/issuer"
+        - path: "/api"
           pathType: "Prefix"
           backend:
             port: 8080

--- a/src/database/SsiCredentialIssuer.DbAccess/Models/CredentialDetailData.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Models/CredentialDetailData.cs
@@ -21,8 +21,7 @@ using Org.Eclipse.TractusX.SsiCredentialIssuer.Entities.Enums;
 
 namespace Org.Eclipse.TractusX.SsiCredentialIssuer.DBAccess.Models;
 
-public record CredentialDetailData
-(
+public record CredentialDetailData(
     Guid CredentialDetailId,
     string Bpnl,
     VerifiedCredentialTypeId CredentialType,


### PR DESCRIPTION
## Description

Adjust the api path to handle the requests to api/revocation and api/credential as well.

... and improve formatting

## Why

The ingress blocks requests to the api/recovation and api/credential endpoints

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
