### PR TITLE
fix(revocation): save database changes afert revocation

### DIFF
--- a/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/RevocationBusinessLogic.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/RevocationBusinessLogic.cs
@@ -78,5 +78,7 @@ public class RevocationBusinessLogic : IRevocationBusinessLogic
         credentialRepository.AttachAndModifyCredential(credentialId,
             x => x.CompanySsiDetailStatusId = data.StatusId,
             x => x.CompanySsiDetailStatusId = CompanySsiDetailStatusId.REVOKED);
+
+        await _repositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
     }
 }


### PR DESCRIPTION
## Description

Save the database changes after the revocation of the credential

## Why

To have the new and correct status in the database

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
