### PR TITLE
docs: add known knowns section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Run the following command from the CLI in the directory of the service you want 
 dotnet run
 ```
 
+## Known Issues and Limitations
+
+- The database is capable of storing documents of type `PRESENTATION` through a POST API call, even though this functionality is not exposed through any specific API endpoint, indicating an undocumented feature or a future use case not yet realized.
+
+- The DIM Status List is presently included in both the configuration file and the outbound wallet post body, which is against our recommendation as we believe this function should be autonomously managed by the wallet. The status list is defined within the component configuration, suggesting an interim solution with an intention to phase out this approach, reinforcing that the status list should not be integral to the interface in the long term.
+
 ## Notice for Docker image
 
 This application provides container images for demonstration purposes.

--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ dotnet run
 
 ## Known Issues and Limitations
 
-- The database is capable of storing documents of type `PRESENTATION` through a POST API call, even though this functionality is not exposed through any specific API endpoint, indicating an undocumented feature or a future use case not yet realized.
-
-- The DIM Status List is presently included in both the configuration file and the outbound wallet post body, which is against our recommendation as we believe this function should be autonomously managed by the wallet. The status list is defined within the component configuration, suggesting an interim solution with an intention to phase out this approach, reinforcing that the status list should not be integral to the interface in the long term.
+See [Known Knowns](/docs/technical-documentation/known-knowns/known-issues-and-limitations.md).
 
 ## Notice for Docker image
 

--- a/docs/technical-documentation/known-knowns/known-issues-and-limitations.md
+++ b/docs/technical-documentation/known-knowns/known-issues-and-limitations.md
@@ -1,0 +1,13 @@
+## Known Issues and Limitations
+
+- The database is capable of storing documents of type `PRESENTATION` through a POST API call, even though this functionality is not exposed through any specific API endpoint, indicating an undocumented feature or a future use case not yet realized.
+
+- The DIM Status List is presently included in both the configuration file and the outbound wallet post body, which is against our recommendation as we believe this function should be autonomously managed by the wallet. The status list is defined within the component configuration, suggesting an interim solution with an intention to phase out this approach, reinforcing that the status list should not be integral to the interface in the long term.
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/ssi-credential-issuer

--- a/docs/technical-documentation/known-knowns/known-issues-and-limitations.md
+++ b/docs/technical-documentation/known-knowns/known-issues-and-limitations.md
@@ -1,4 +1,4 @@
-## Known Issues and Limitations
+# Known Issues and Limitations
 
 - The database is capable of storing documents of type `PRESENTATION` through a POST API call, even though this functionality is not exposed through any specific API endpoint, indicating an undocumented feature or a future use case not yet realized.
 


### PR DESCRIPTION
## Description

Added a Known Issues and Limitations section to the readme

## Why

To display the known knowns to the user

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
