### PR TITLE
chore(consortia): fix ingress in environment specific config

### DIFF
--- a/consortia/environments/values-beta.yaml
+++ b/consortia/environments/values-beta.yaml
@@ -36,7 +36,7 @@ ingress:
   hosts:
     - host: "ssi-credential-issuer.beta.demo.catena-x.net"
       paths:
-        - path: "/api/issuer"
+        - path: "/api"
           pathType: "Prefix"
           backend:
             port: 8080

--- a/consortia/environments/values-dev.yaml
+++ b/consortia/environments/values-dev.yaml
@@ -36,7 +36,7 @@ ingress:
   hosts:
     - host: "ssi-credential-issuer.dev.demo.catena-x.net"
       paths:
-        - path: "/api/issuer"
+        - path: "/api"
           pathType: "Prefix"
           backend:
             port: 8080

--- a/consortia/environments/values-int.yaml
+++ b/consortia/environments/values-int.yaml
@@ -36,7 +36,7 @@ ingress:
   hosts:
     - host: "ssi-credential-issuer.int.demo.catena-x.net"
       paths:
-        - path: "/api/issuer"
+        - path: "/api"
           pathType: "Prefix"
           backend:
             port: 8080

--- a/consortia/environments/values-pen.yaml
+++ b/consortia/environments/values-pen.yaml
@@ -36,7 +36,7 @@ ingress:
   hosts:
     - host: "ssi-credential-issuer-pen.dev.demo.catena-x.net"
       paths:
-        - path: "/api/issuer"
+        - path: "/api"
           pathType: "Prefix"
           backend:
             port: 8080

--- a/consortia/environments/values-rc.yaml
+++ b/consortia/environments/values-rc.yaml
@@ -36,7 +36,7 @@ ingress:
   hosts:
     - host: "ssi-credential-issuer-rc.dev.demo.catena-x.net"
       paths:
-        - path: "/api/issuer"
+        - path: "/api"
           pathType: "Prefix"
           backend:
             port: 8080


### PR DESCRIPTION
## Description

Fix the ingress configuration for each environment

## Why

Requests to /api/revocation lead to an 404 due to a wrong ingress configuration

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
