### PR TITLE
fix(expiry): set expiry to max 1 year

### DIFF
--- a/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
@@ -440,7 +440,7 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
             externalTypeId,
             $"Framework Credential for UseCase {externalTypeId}",
             DateTimeOffset.UtcNow,
-            result.Expiry,
+            GetExpiryDate(result.Expiry),
             _settings.IssuerDid,
             new FrameworkCredentialSubject(
                 holderDid,


### PR DESCRIPTION
## Description

Set the expiry to max 1 year for framework credentials if the expiry for the detail version is longer than 1 year.

## Why

To have the credentials validity max one year in the future

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
