### PR TITLE
ci: fix actions/cache in sonarcloud

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -48,14 +48,14 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Cache SonarCloud packages
-        uses: actions/cache@c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: ~/sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache SonarCloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: ./.sonar/scanner
           key: ${{ runner.os }}-sonar-scanner


### PR DESCRIPTION
## Description

fix actions/cache in sonarcloud: change commit sha

## Why

Error: Unable to resolve action `actions/cache@c45773b623bea8c8e75f6c82b208c3cf94ea4f9`, unable to find version `c45773b623bea8c8e75f6c82b208c3cf94ea4f9`
Inroduced with https://github.com/eclipse-tractusx/ssi-credential-issuer/pull/177

## Checklist

- [x] I have successfully tested my changes
