### PR TITLE
fix: adjust exceptionhandling for encryption

### DIFF
--- a/src/credentials/SsiCredentialIssuer.Expiry.App/Program.cs
+++ b/src/credentials/SsiCredentialIssuer.Expiry.App/Program.cs
@@ -67,5 +67,5 @@ catch (Exception ex) when (!ex.GetType().Name.Equals("StopTheHostException", Str
 finally
 {
     Log.Information("Server Shutting down");
-    Log.CloseAndFlush();
+    await Log.CloseAndFlushAsync().ConfigureAwait(false);
 }

--- a/src/credentials/SsiCredentialIssuer.Expiry.App/SsiCredentialIssuer.Expiry.App.csproj
+++ b/src/credentials/SsiCredentialIssuer.Expiry.App/SsiCredentialIssuer.Expiry.App.csproj
@@ -42,9 +42,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="2.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="2.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="2.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/database/SsiCredentialIssuer.DbAccess/SsiCredentialIssuer.DbAccess.csproj
+++ b/src/database/SsiCredentialIssuer.DbAccess/SsiCredentialIssuer.DbAccess.csproj
@@ -27,9 +27,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.4" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.3.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/database/SsiCredentialIssuer.Entities/SsiCredentialIssuer.Entities.csproj
+++ b/src/database/SsiCredentialIssuer.Entities/SsiCredentialIssuer.Entities.csproj
@@ -33,10 +33,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="2.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess" Version="2.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Linq" Version="2.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="2.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess" Version="2.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Linq" Version="2.3.0" />
   </ItemGroup>
   <ItemGroup>
     <SonarQubeSetting Include="sonar.coverage.exclusions">

--- a/src/database/SsiCredentialIssuer.Migrations/Program.cs
+++ b/src/database/SsiCredentialIssuer.Migrations/Program.cs
@@ -50,7 +50,7 @@ try
         .AddLogging()
         .Build();
 
-    await host.Services.InitializeDatabasesAsync(); // We don't actually run anything here. The magic happens in InitializeDatabasesAsync
+    await host.Services.InitializeDatabasesAsync().ConfigureAwait(false); // We don't actually run anything here. The magic happens in InitializeDatabasesAsync
 }
 catch (Exception ex) when (!ex.GetType().Name.Equals("StopTheHostException", StringComparison.Ordinal))
 {
@@ -60,5 +60,5 @@ catch (Exception ex) when (!ex.GetType().Name.Equals("StopTheHostException", Str
 finally
 {
     Log.Information("Process Shutting down...");
-    Log.CloseAndFlush();
+    await Log.CloseAndFlushAsync().ConfigureAwait(false);
 }

--- a/src/database/SsiCredentialIssuer.Migrations/SsiCredentialIssuer.Migrations.csproj
+++ b/src/database/SsiCredentialIssuer.Migrations/SsiCredentialIssuer.Migrations.csproj
@@ -34,8 +34,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Laraue.EfCoreTriggers.PostgreSql" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -48,8 +48,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="2.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="2.3.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/externalservices/Callback.Service/Callback.Service.csproj
+++ b/src/externalservices/Callback.Service/Callback.Service.csproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="2.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="2.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/externalservices/Portal.Service/Portal.Service.csproj
+++ b/src/externalservices/Portal.Service/Portal.Service.csproj
@@ -30,7 +30,7 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="2.0.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="2.3.0" />
     </ItemGroup>
 
 </Project>

--- a/src/externalservices/Wallet.Service/Wallet.Service.csproj
+++ b/src/externalservices/Wallet.Service/Wallet.Service.csproj
@@ -33,8 +33,8 @@
     <PackageReference Include="JsonSchema.Net" Version="6.1.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="2.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="2.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="2.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="2.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="Schemas\BpnCredential.schema.json">

--- a/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
@@ -23,7 +23,7 @@ using Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.HttpClientExtensions;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
-using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Encryption;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Configuration;
 using Org.Eclipse.TractusX.SsiCredentialIssuer.DBAccess;
 using Org.Eclipse.TractusX.SsiCredentialIssuer.DBAccess.Models;
 using Org.Eclipse.TractusX.SsiCredentialIssuer.DBAccess.Repositories;
@@ -525,13 +525,13 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
                     return;
                 }
 
-                var cryptoConfig = _settings.EncryptionConfigs.SingleOrDefault(x => x.Index == _settings.EncrptionConfigIndex) ?? throw new ConfigurationException($"EncryptionModeIndex {_settings.EncrptionConfigIndex} is not configured");
-                var (secret, initializationVector) = CryptoHelper.Encrypt(technicalUserDetails.ClientSecret, Convert.FromHexString(cryptoConfig.EncryptionKey), cryptoConfig.CipherMode, cryptoConfig.PaddingMode);
+                var cryptoHelper = _settings.EncryptionConfigs.GetCryptoHelper(_settings.EncryptionConfigIndex);
+                var (secret, initializationVector) = cryptoHelper.Encrypt(technicalUserDetails.ClientSecret);
 
                 c.ClientId = technicalUserDetails.ClientId;
                 c.ClientSecret = secret;
                 c.InitializationVector = initializationVector;
-                c.EncryptionMode = _settings.EncrptionConfigIndex;
+                c.EncryptionMode = _settings.EncryptionConfigIndex;
                 c.HolderWalletUrl = technicalUserDetails.WalletUrl;
                 c.CallbackUrl = callbackUrl;
             });

--- a/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerSettings.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerSettings.cs
@@ -40,7 +40,7 @@ public class IssuerSettings
     public IEnumerable<EncryptionModeConfig> EncryptionConfigs { get; set; } = null!;
 
     [Required]
-    public int EncrptionConfigIndex { get; set; }
+    public int EncryptionConfigIndex { get; set; }
 
     [Required(AllowEmptyStrings = false)]
     public string StatusListUrl { get; set; } = null!;

--- a/src/issuer/SsiCredentialIssuer.Service/Program.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/Program.cs
@@ -34,8 +34,8 @@ using System.Text.Json.Serialization;
 
 const string VERSION = "v1";
 
-WebApplicationBuildRunner
-    .BuildAndRunWebApplication<Program>(args, "issuer", VERSION, ".Issuer", builder =>
+await WebApplicationBuildRunner
+    .BuildAndRunWebApplicationAsync<Program>(args, "issuer", VERSION, ".Issuer", builder =>
         {
             builder.Services
                 .AddTransient<IClaimsTransformation, KeycloakClaimsTransformation>()
@@ -67,4 +67,4 @@ WebApplicationBuildRunner
             .MapIssuerApi()
             .MapRevocationApi()
             .MapCredentialApi();
-    });
+    }).ConfigureAwait(ConfigureAwaitOptions.None);

--- a/src/issuer/SsiCredentialIssuer.Service/SsiCredentialIssuer.Service.csproj
+++ b/src/issuer/SsiCredentialIssuer.Service/SsiCredentialIssuer.Service.csproj
@@ -39,8 +39,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="2.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="2.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="2.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="2.3.0" />
     <PackageReference Include="PasswordGenerator" Version="2.1.0" />
     <PackageReference Include="System.Json" Version="4.7.1" />
   </ItemGroup>

--- a/src/processes/Processes.Worker.Library/Processes.Worker.Library.csproj
+++ b/src/processes/Processes.Worker.Library/Processes.Worker.Library.csproj
@@ -33,9 +33,9 @@
       <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Async" Version="2.0.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="2.0.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.0.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Async" Version="2.3.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="2.3.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.3.0" />
       <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     </ItemGroup>
 

--- a/src/processes/Processes.Worker/Processes.Worker.csproj
+++ b/src/processes/Processes.Worker/Processes.Worker.csproj
@@ -42,8 +42,8 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.0.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="2.0.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.3.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="2.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/processes/Processes.Worker/Program.cs
+++ b/src/processes/Processes.Worker/Program.cs
@@ -71,5 +71,5 @@ catch (Exception ex) when (!ex.GetType().Name.Equals("StopTheHostException", Str
 finally
 {
     Log.Information("Server Shutting down");
-    Log.CloseAndFlush();
+    await Log.CloseAndFlushAsync().ConfigureAwait(false);
 }

--- a/tests/database/SsiCredentialIssuer.DbAccess.Tests/SsiCredentialIssuer.DbAccess.Tests.csproj
+++ b/tests/database/SsiCredentialIssuer.DbAccess.Tests/SsiCredentialIssuer.DbAccess.Tests.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.17" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="2.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="2.3.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="3.4.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="Xunit.Extensions.AssemblyFixture" Version="2.4.1" />

--- a/tests/externalservices/Wallet.Service.Tests/Wallet.Service.Tests.csproj
+++ b/tests/externalservices/Wallet.Service.Tests/Wallet.Service.Tests.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.17" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.17" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web" Version="2.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web" Version="2.3.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="3.4.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">

--- a/tests/issuer/SsiCredentialIssuer.Service.Tests/BusinessLogic/IssuerBusinessLogicTests.cs
+++ b/tests/issuer/SsiCredentialIssuer.Service.Tests/BusinessLogic/IssuerBusinessLogicTests.cs
@@ -103,7 +103,7 @@ public class IssuerBusinessLogicTests
             MaxPageSize = 15,
             IssuerDid = "did:web:example:org:bpn:18273z682734rt",
             IssuerBpn = IssuerBpnl,
-            EncrptionConfigIndex = 0,
+            EncryptionConfigIndex = 0,
             StatusListUrl = "https://example.org/statuslist"
         });
 


### PR DESCRIPTION
## Description

Exception-handling was added to the CryptoHelper to properly map the System-exceptions that are thrown by the Aes-classes to Configuration resp. ConflictExceptions

## Why

To handle the exceptions thrown by the cryptoHandler to handle the failing process steps correctly

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
