### PR TITLE
Bug/implement expiry for bpnl and membership credentials

### DIFF
--- a/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
@@ -337,6 +337,7 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
     {
         var companyCredentialDetailsRepository = _repositories.GetInstance<ICompanySsiDetailsRepository>();
         var holderDid = await GetHolderInformation(requestData.Holder, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        var expiryDate = DateTimeOffset.UtcNow.AddMonths(12);
         var schemaData = new BpnCredential(
             Guid.NewGuid(),
             Context,
@@ -344,7 +345,7 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
             "BpnCredential",
             "Bpn Credential",
             DateTimeOffset.UtcNow,
-            DateTimeOffset.UtcNow.AddMonths(12),
+            expiryDate,
             _settings.IssuerDid,
             new BpnCredentialSubject(
                 holderDid,
@@ -356,7 +357,7 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
                 StatusList)
         );
         var schema = JsonSerializer.Serialize(schemaData, Options);
-        return await HandleCredentialProcessCreation(requestData.BusinessPartnerNumber, VerifiedCredentialTypeKindId.BPN, VerifiedCredentialTypeId.BUSINESS_PARTNER_NUMBER, schema, requestData.TechnicalUserDetails, null, requestData.CallbackUrl, companyCredentialDetailsRepository);
+        return await HandleCredentialProcessCreation(requestData.BusinessPartnerNumber, VerifiedCredentialTypeKindId.BPN, VerifiedCredentialTypeId.BUSINESS_PARTNER_NUMBER, expiryDate, schema, requestData.TechnicalUserDetails, null, requestData.CallbackUrl, companyCredentialDetailsRepository);
     }
 
     public async Task<Guid> CreateMembershipCredential(CreateMembershipCredentialRequest requestData, CancellationToken cancellationToken)
@@ -364,6 +365,7 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
         var companyCredentialDetailsRepository = _repositories.GetInstance<ICompanySsiDetailsRepository>();
 
         var holderDid = await GetHolderInformation(requestData.Holder, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
+        var expiryDate = DateTimeOffset.UtcNow.AddMonths(12);
         var schemaData = new MembershipCredential(
             Guid.NewGuid(),
             Context,
@@ -371,7 +373,7 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
             "MembershipCredential",
             "Membership Credential",
             DateTimeOffset.UtcNow,
-            DateTimeOffset.UtcNow.AddMonths(12),
+            expiryDate,
             _settings.IssuerDid,
             new MembershipCredentialSubject(
                 holderDid,
@@ -383,7 +385,7 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
                 StatusList)
         );
         var schema = JsonSerializer.Serialize(schemaData, Options);
-        return await HandleCredentialProcessCreation(requestData.HolderBpn, VerifiedCredentialTypeKindId.MEMBERSHIP, VerifiedCredentialTypeId.MEMBERSHIP_CERTIFICATE, schema, requestData.TechnicalUserDetails, null, requestData.CallbackUrl, companyCredentialDetailsRepository);
+        return await HandleCredentialProcessCreation(requestData.HolderBpn, VerifiedCredentialTypeKindId.MEMBERSHIP, VerifiedCredentialTypeId.MEMBERSHIP_CERTIFICATE, expiryDate, schema, requestData.TechnicalUserDetails, null, requestData.CallbackUrl, companyCredentialDetailsRepository);
     }
 
     public async Task<Guid> CreateFrameworkCredential(CreateFrameworkCredentialRequest requestData, CancellationToken cancellationToken)
@@ -454,12 +456,12 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
                 StatusList)
         );
         var schema = JsonSerializer.Serialize(schemaData, Options);
-        return await HandleCredentialProcessCreation(requestData.HolderBpn, VerifiedCredentialTypeKindId.FRAMEWORK, requestData.UseCaseFrameworkId, schema, requestData.TechnicalUserDetails, requestData.UseCaseFrameworkVersionId, requestData.CallbackUrl, companyCredentialDetailsRepository);
+        return await HandleCredentialProcessCreation(requestData.HolderBpn, VerifiedCredentialTypeKindId.FRAMEWORK, requestData.UseCaseFrameworkId, result.Expiry, schema, requestData.TechnicalUserDetails, requestData.UseCaseFrameworkVersionId, requestData.CallbackUrl, companyCredentialDetailsRepository);
     }
 
     private async Task<string> GetHolderInformation(string didDocumentLocation, CancellationToken cancellationToken)
     {
-        if (!Uri.TryCreate(didDocumentLocation, UriKind.Absolute, out var uri) || uri.Scheme != "https" || !string.IsNullOrEmpty(uri.Query) || !string.IsNullOrEmpty(uri.Fragment) || UrlPathInvalidCharsRegex.IsMatch(uri.AbsolutePath))
+        if (!Uri.TryCreate(didDocumentLocation, UriKind.Absolute, out var uri) || (uri.Scheme != "https" || !string.IsNullOrEmpty(uri.Query) || !string.IsNullOrEmpty(uri.Fragment) || UrlPathInvalidCharsRegex.IsMatch(uri.AbsolutePath))
         {
             throw ControllerArgumentException.Create(IssuerErrors.INVALID_DID_LOCATION, null, nameof(didDocumentLocation));
         }
@@ -480,6 +482,7 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
         string bpnl,
         VerifiedCredentialTypeKindId kindId,
         VerifiedCredentialTypeId typeId,
+        DateTimeOffset expiryDate,
         string schema,
         TechnicalUserDetails? technicalUserDetails,
         Guid? detailVersionId,
@@ -514,6 +517,7 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
             {
                 c.VerifiedCredentialExternalTypeDetailVersionId = detailVersionId;
                 c.ProcessId = processId;
+                c.ExpiryDate = expiryDate;
             }).Id;
         documentRepository.AssignDocumentToCompanySsiDetails(docId, ssiDetailId);
 

--- a/tests/issuer/SsiCredentialIssuer.Service.Tests/BusinessLogic/IssuerBusinessLogicTests.cs
+++ b/tests/issuer/SsiCredentialIssuer.Service.Tests/BusinessLogic/IssuerBusinessLogicTests.cs
@@ -676,12 +676,17 @@ public class IssuerBusinessLogicTests
         var didId = Guid.NewGuid().ToString();
         var didDocument = new DidDocument(didId);
         var data = new CreateBpnCredentialRequest("https://example.org/holder/BPNL12343546/did.json", Bpnl, null, null);
+        var detail = new CompanySsiDetail(CredentialId, _identity.Bpnl, VerifiedCredentialTypeId.BUSINESS_PARTNER_NUMBER, CompanySsiDetailStatusId.ACTIVE, IssuerBpnl, _identity.IdentityId, DateTimeOffset.Now);
+
         HttpRequestMessage? request = null;
         ConfigureHttpClientFactoryFixture(new HttpResponseMessage
         {
             StatusCode = HttpStatusCode.OK,
             Content = new StringContent(JsonSerializer.Serialize(didDocument))
         }, requestMessage => request = requestMessage);
+
+        A.CallTo(() => _companySsiDetailsRepository.CreateSsiDetails(_identity.Bpnl, VerifiedCredentialTypeId.BUSINESS_PARTNER_NUMBER, CompanySsiDetailStatusId.ACTIVE, IssuerBpnl, _identity.IdentityId, A<Action<CompanySsiDetail>>._))
+            .Invokes((string bpnl, VerifiedCredentialTypeId verifiedCredentialTypeId, CompanySsiDetailStatusId companySsiDetailStatusId, string issuerBpn, string userId, Action<CompanySsiDetail>? setOptionalFields) => setOptionalFields?.Invoke(detail));
 
         // Act
         await _sut.CreateBpnCredential(data, CancellationToken.None);
@@ -694,6 +699,7 @@ public class IssuerBusinessLogicTests
         A.CallTo(() => _documentRepository.AssignDocumentToCompanySsiDetails(A<Guid>._, A<Guid>._))
             .MustHaveHappenedOnceExactly();
         A.CallTo(() => _issuerRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
+        Assert.NotNull(detail.ExpiryDate);
     }
 
     [Theory]
@@ -746,6 +752,8 @@ public class IssuerBusinessLogicTests
         var didId = Guid.NewGuid().ToString();
         var didDocument = new DidDocument(didId);
         var data = new CreateMembershipCredentialRequest("https://example.org/holder/BPNL12343546/did.json", Bpnl, "Test", null, null);
+        var detail = new CompanySsiDetail(CredentialId, _identity.Bpnl, VerifiedCredentialTypeId.DISMANTLER_CERTIFICATE, CompanySsiDetailStatusId.ACTIVE, IssuerBpnl, _identity.IdentityId, DateTimeOffset.Now);
+
         HttpRequestMessage? request = null;
         A.CallTo(() => _companySsiDetailsRepository.GetCertificateTypes(A<string>._))
             .Returns(Enum.GetValues<VerifiedCredentialTypeId>().ToAsyncEnumerable());
@@ -754,6 +762,9 @@ public class IssuerBusinessLogicTests
             StatusCode = HttpStatusCode.OK,
             Content = new StringContent(JsonSerializer.Serialize(didDocument))
         }, requestMessage => request = requestMessage);
+
+        A.CallTo(() => _companySsiDetailsRepository.CreateSsiDetails(_identity.Bpnl, VerifiedCredentialTypeId.DISMANTLER_CERTIFICATE, CompanySsiDetailStatusId.ACTIVE, IssuerBpnl, _identity.IdentityId, A<Action<CompanySsiDetail>>._))
+            .Invokes((string bpnl, VerifiedCredentialTypeId verifiedCredentialTypeId, CompanySsiDetailStatusId companySsiDetailStatusId, string issuerBpn, string userId, Action<CompanySsiDetail>? setOptionalFields) => setOptionalFields?.Invoke(detail));
 
         // Act
         await _sut.CreateMembershipCredential(data, CancellationToken.None);
@@ -766,6 +777,7 @@ public class IssuerBusinessLogicTests
         A.CallTo(() => _documentRepository.AssignDocumentToCompanySsiDetails(A<Guid>._, A<Guid>._))
             .MustHaveHappenedOnceExactly();
         A.CallTo(() => _issuerRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
+        Assert.NotNull(detail.ExpiryDate);
     }
 
     #endregion


### PR DESCRIPTION
## Description

There is a bug within the company_ssi_details table where BPNL (Business Partner Number Legal) and Membership credentials are being issued without an expiry date. 

## Why

In order to fix the bug a the expiry date have to be created when issuing a BPN and Membership credential

## Issue

N/A

## Checklist

Please delete options that are not relevant.

- [X] I have followed the contributing guidelines

- [X] I have performed a self-review of my own code

- [X] I have successfully tested my changes locally

- [X] I have added tests and updated existing tests that prove my changes work

- [X] I have checked that new and existing tests pass locally with my changes
