### PR TITLE
fix: Added the correct type for owned-credentials method

### DIFF
--- a/src/issuer/SsiCredentialIssuer.Service/Controllers/IssuerController.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/Controllers/IssuerController.cs
@@ -104,7 +104,7 @@ public static class IssuerController
                 r.AddRequirements(new MandatoryIdentityClaimRequirement(PolicyTypeId.ValidBpn));
             })
             .WithDefaultResponses()
-            .Produces(StatusCodes.Status200OK, typeof(IEnumerable<CredentialDetailData>), Constants.JsonContentType);
+            .Produces(StatusCodes.Status200OK, typeof(IEnumerable<OwnedVerifiedCredentialData>), Constants.JsonContentType);
 
         issuer.MapPost("bpn", ([FromBody] CreateBpnCredentialRequest requestData, CancellationToken cancellationToken, IIssuerBusinessLogic logic) => logic.CreateBpnCredential(requestData, cancellationToken))
             .WithSwaggerDescription("Creates a bpn credential for the given data",


### PR DESCRIPTION
## Description

Changed the object type CredentialDetailData to OwnedVerifiedCredentialData in the response of the Endpoint GET /api/issuer/owned-credentials.

## Why

The current OpenAI documentation for the endpoint GET /api/issuer/owned-credentials displays an incorrect response body

## Issue

N/A

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added copyright and license headers, footers (for .md files) or files (for images)
