### PR TITLE
fix(cronjob expiry): added the missing environment value for portal

### DIFF
--- a/charts/ssi-credential-issuer/templates/cronjob-expiry-app.yaml
+++ b/charts/ssi-credential-issuer/templates/cronjob-expiry-app.yaml
@@ -72,7 +72,7 @@ spec:
               value: "{{ .Values.credentialExpiry.expiry.inactiveVcsToDeleteInWeeks }}"
             - name: "PROCESSES__IDENTITYID"
               value: "{{ .Values.credentialExpiry.processIdentity.identityId }}"
-                        - name: "PORTAL__CLIENTID"
+            - name: "PORTAL__CLIENTID"
               value: "{{ .Values.issuer.portal.clientId }}"
             - name: "PORTAL__CLIENTSECRET"
               valueFrom:

--- a/charts/ssi-credential-issuer/templates/cronjob-expiry-app.yaml
+++ b/charts/ssi-credential-issuer/templates/cronjob-expiry-app.yaml
@@ -72,6 +72,25 @@ spec:
               value: "{{ .Values.credentialExpiry.expiry.inactiveVcsToDeleteInWeeks }}"
             - name: "PROCESSES__IDENTITYID"
               value: "{{ .Values.credentialExpiry.processIdentity.identityId }}"
+                        - name: "PORTAL__CLIENTID"
+              value: "{{ .Values.issuer.portal.clientId }}"
+            - name: "PORTAL__CLIENTSECRET"
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ template "issuer.secretName" . }}"
+                  key: "portal-client-secret"
+            - name: "PORTAL__GRANTTYPE"
+              value: "{{ .Values.processesworker.portal.grantType }}"
+            - name: "PORTAL__TOKENADDRESS"
+              value: "{{ .Values.centralidp.address }}{{ .Values.centralidp.tokenPath }}"
+            - name: "PORTAL__BASEADDRESS"
+              value: "{{ .Values.portalBackendAddress }}"
+            - name: "PORTAL__PASSWORD"
+              value: "empty"
+            - name: "PORTAL__SCOPE"
+              value: "{{ .Values.processesworker.portal.scope }}"
+            - name: "PORTAL__USERNAME"
+              value: "empty"
             ports:
             - name: http
               containerPort: {{ .Values.portContainer }}

--- a/charts/ssi-credential-issuer/templates/cronjob-expiry-app.yaml
+++ b/charts/ssi-credential-issuer/templates/cronjob-expiry-app.yaml
@@ -73,7 +73,7 @@ spec:
             - name: "PROCESSES__IDENTITYID"
               value: "{{ .Values.credentialExpiry.processIdentity.identityId }}"
             - name: "PORTAL__CLIENTID"
-              value: "{{ .Values.issuer.portal.clientId }}"
+              value: "{{ .Values.service.portal.clientId }}"
             - name: "PORTAL__CLIENTSECRET"
               valueFrom:
                 secretKeyRef:

--- a/src/credentials/SsiCredentialIssuer.Expiry.App/appsettings.json
+++ b/src/credentials/SsiCredentialIssuer.Expiry.App/appsettings.json
@@ -29,5 +29,15 @@
   },
   "ProcessIdentity": {
     "ProcessUserId": ""
+  },
+  "Portal": {
+    "Username": "",
+    "Password": "",
+    "ClientId": "",
+    "GrantType": "",
+    "ClientSecret": "",
+    "Scope": "",
+    "TokenAddress": "",
+    "BaseAddress": ""
   }
 }


### PR DESCRIPTION
## Description

Added environment value for PortalSettings in `charts/ssi-credential-issuer/templates/cronjob-expiry-app.yaml` 
fixes  #195 
closes #195 

## Why

To run this project PortalSettings are required

## Issue

[Issue #195](https://github.com/eclipse-tractusx/ssi-credential-issuer/issues/195)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
