### PR TITLE
fix(expiry): adjust removal of companySsiDetails

### DIFF
--- a/charts/ssi-credential-issuer/templates/cronjob-expiry-app.yaml
+++ b/charts/ssi-credential-issuer/templates/cronjob-expiry-app.yaml
@@ -70,7 +70,7 @@ spec:
               value: "{{ .Values.credentialExpiry.expiry.expiredVcsToDeleteInMonth }}"
             - name: "EXPIRY__INACTIVEVCSTODELETEINWEEKS"
               value: "{{ .Values.credentialExpiry.expiry.inactiveVcsToDeleteInWeeks }}"
-            - name: "PROCESSES__IDENTITYID"
+            - name: "PROCESSIDENTITY__IDENTITYID"
               value: "{{ .Values.credentialExpiry.processIdentity.identityId }}"
             - name: "PORTAL__CLIENTID"
               value: "{{ .Values.service.portal.clientId }}"

--- a/src/credentials/SsiCredentialIssuer.Expiry.App/ExpiryCheckService.cs
+++ b/src/credentials/SsiCredentialIssuer.Expiry.App/ExpiryCheckService.cs
@@ -109,7 +109,7 @@ public class ExpiryCheckService
     {
         if (data.ScheduleData.IsVcToDelete)
         {
-            companySsiDetailsRepository.RemoveSsiDetail(data.Id);
+            companySsiDetailsRepository.RemoveSsiDetail(data.Id, data.Bpnl, data.RequesterId);
         }
         else if (data.ScheduleData.IsVcToDecline)
         {

--- a/src/credentials/SsiCredentialIssuer.Expiry.App/appsettings.json
+++ b/src/credentials/SsiCredentialIssuer.Expiry.App/appsettings.json
@@ -28,7 +28,7 @@
     "InactiveVcsToDeleteInWeeks": 12
   },
   "ProcessIdentity": {
-    "ProcessUserId": ""
+    "IdentityId": ""
   },
   "Portal": {
     "Username": "",

--- a/src/database/SsiCredentialIssuer.DbAccess/Repositories/ICompanySsiDetailsRepository.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Repositories/ICompanySsiDetailsRepository.cs
@@ -100,7 +100,7 @@ public interface ICompanySsiDetailsRepository
     void AttachAndModifyCompanySsiDetails(Guid id, Action<CompanySsiDetail>? initialize, Action<CompanySsiDetail> updateFields);
     IAsyncEnumerable<VerifiedCredentialTypeId> GetCertificateTypes(string bpnl);
     IAsyncEnumerable<CredentialExpiryData> GetExpiryData(DateTimeOffset now, DateTimeOffset inactiveVcsToDelete, DateTimeOffset expiredVcsToDelete);
-    void RemoveSsiDetail(Guid companySsiDetailId);
+    void RemoveSsiDetail(Guid companySsiDetailId, string bpnl, string userId);
     void CreateProcessData(Guid companySsiDetailId, JsonDocument schema, VerifiedCredentialTypeKindId credentialTypeKindId, Action<CompanySsiProcessData>? setOptionalFields);
     void AttachAndModifyProcessData(Guid companySsiDetailId, Action<CompanySsiProcessData>? initialize, Action<CompanySsiProcessData> setOptionalFields);
 }

--- a/src/database/SsiCredentialIssuer.DbAccess/SsiCredentialIssuer.DbAccess.csproj
+++ b/src/database/SsiCredentialIssuer.DbAccess/SsiCredentialIssuer.DbAccess.csproj
@@ -24,6 +24,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>6095f568-c370-4ea3-b510-8c992115cc44</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/credentials/SsiCredentialIssuer.Expiry.App.Tests/ExpiryCheckServiceTests.cs
+++ b/tests/credentials/SsiCredentialIssuer.Expiry.App.Tests/ExpiryCheckServiceTests.cs
@@ -106,7 +106,7 @@ public class ExpiryCheckServiceTests
         await _sut.ExecuteAsync(CancellationToken.None);
 
         // Assert
-        A.CallTo(() => _companySsiDetailsRepository.RemoveSsiDetail(credentialId)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => _companySsiDetailsRepository.RemoveSsiDetail(credentialId, A<string>._, A<string>._)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _issuerRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
     }
 
@@ -137,7 +137,7 @@ public class ExpiryCheckServiceTests
         await _sut.ExecuteAsync(CancellationToken.None);
 
         // Assert
-        A.CallTo(() => _companySsiDetailsRepository.RemoveSsiDetail(ssiDetail.Id)).MustNotHaveHappened();
+        A.CallTo(() => _companySsiDetailsRepository.RemoveSsiDetail(ssiDetail.Id, A<string>._, A<string>._)).MustNotHaveHappened();
         A.CallTo(() => _issuerRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
         A.CallTo(() => _processStepRepository.CreateProcess(ProcessTypeId.DECLINE_CREDENTIAL)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _processStepRepository.CreateProcessStep(ProcessStepTypeId.REVOKE_CREDENTIAL, ProcessStepStatusId.TODO, A<Guid>._)).MustHaveHappenedOnceExactly();
@@ -183,7 +183,7 @@ public class ExpiryCheckServiceTests
         await _sut.ExecuteAsync(CancellationToken.None);
 
         // Assert
-        A.CallTo(() => _companySsiDetailsRepository.RemoveSsiDetail(ssiDetail.Id)).MustNotHaveHappened();
+        A.CallTo(() => _companySsiDetailsRepository.RemoveSsiDetail(ssiDetail.Id, A<string>._, A<string>._)).MustNotHaveHappened();
         A.CallTo(() => _issuerRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
         A.CallTo(() => _portalService.AddNotification(A<string>._, creatorUserId, NotificationTypeId.CREDENTIAL_EXPIRY, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
         A.CallTo(() => _portalService.TriggerMail("CredentialExpiry", creatorUserId, A<IEnumerable<MailParameter>>._, A<CancellationToken>._)).MustHaveHappenedOnceExactly();

--- a/tests/database/SsiCredentialIssuer.DbAccess.Tests/CompanySsiDetailsRepositoryTests.cs
+++ b/tests/database/SsiCredentialIssuer.DbAccess.Tests/CompanySsiDetailsRepositoryTests.cs
@@ -554,7 +554,7 @@ public class CompanySsiDetailsRepositoryTests
         var (sut, context) = await CreateSutWithContext();
 
         // Act
-        sut.RemoveSsiDetail(Guid.NewGuid());
+        sut.RemoveSsiDetail(Guid.NewGuid(), ValidBpnl, "user1");
 
         // Assert
         var changeTracker = context.ChangeTracker;


### PR DESCRIPTION
## Description

Set the bpn, issuerBpn and creatorUser to default values instead of null to support the auditing when deleting a companySsiDetail

## Why

The auditing was failing due to the bpn being null when deleting the companySsiDetail in the expiry app

## Issue

Refs: #195

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
