### PR TITLE
build(1.1.0-rc.1): bump version and update docs

### DIFF
--- a/charts/ssi-credential-issuer/Chart.yaml
+++ b/charts/ssi-credential-issuer/Chart.yaml
@@ -20,8 +20,8 @@
 apiVersion: v2
 name: ssi-credential-issuer
 type: application
-version: 1.0.0-rc.1
-appVersion: 1.0.0-rc.1
+version: 1.1.0-rc.1
+appVersion: 1.1.0-rc.1
 description: Helm chart for SSI Credential Issuer
 home: https://github.com/eclipse-tractusx/ssi-credential-issuer
 dependencies:

--- a/charts/ssi-credential-issuer/README.md
+++ b/charts/ssi-credential-issuer/README.md
@@ -27,7 +27,7 @@ To use the helm chart as a dependency:
 dependencies:
   - name: ssi-credential-issuer
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 1.0.0-rc.1
+    version: 1.1.0-rc.1
 ```
 
 ## Requirements

--- a/environments/argocd-app-templates/appsetup-int.yaml
+++ b/environments/argocd-app-templates/appsetup-int.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/ssi-credential-issuer
     repoURL: 'https://github.com/eclipse-tractusx/ssi-credential-issuer.git'
-    targetRevision: ssi-credential-issuer-1.0.0-rc.1
+    targetRevision: ssi-credential-issuer-1.1.0-rc.1
     plugin:
       env:
         - name: AVP_SECRET

--- a/environments/consortia/argocd-app-templates/appsetup-int.yaml
+++ b/environments/consortia/argocd-app-templates/appsetup-int.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     path: charts/ssi-credential-issuer
     repoURL: 'https://github.com/eclipse-tractusx/ssi-credential-issuer.git'
-    targetRevision: ssi-credential-issuer-1.0.0-rc.1
+    targetRevision: ssi-credential-issuer-1.1.0-rc.1
     plugin:
       env:
         - name: AVP_SECRET

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <VersionSuffix>rc.1</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Description

redo https://github.com/eclipse-tractusx/ssi-credential-issuer/commit/41847c860457e02ed9304e29b4d920a9834d2eae

## Why

version wasn't bumped to 1.1.0

## Issue

https://github.com/eclipse-tractusx/ssi-credential-issuer/issues/186
