### PR TITLE
chore(dependencies): bump efcore to 8.0.7

### DIFF
--- a/src/credentials/SsiCredentialIssuer.Expiry.App/SsiCredentialIssuer.Expiry.App.csproj
+++ b/src/credentials/SsiCredentialIssuer.Expiry.App/SsiCredentialIssuer.Expiry.App.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/database/SsiCredentialIssuer.DbAccess/SsiCredentialIssuer.DbAccess.csproj
+++ b/src/database/SsiCredentialIssuer.DbAccess/SsiCredentialIssuer.DbAccess.csproj
@@ -28,8 +28,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.7" />
     <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.3.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>

--- a/src/database/SsiCredentialIssuer.Entities/SsiCredentialIssuer.Entities.csproj
+++ b/src/database/SsiCredentialIssuer.Entities/SsiCredentialIssuer.Entities.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
     <PackageReference Include="Laraue.EfCoreTriggers.Common" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/database/SsiCredentialIssuer.Migrations/SsiCredentialIssuer.Migrations.csproj
+++ b/src/database/SsiCredentialIssuer.Migrations/SsiCredentialIssuer.Migrations.csproj
@@ -34,9 +34,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Laraue.EfCoreTriggers.PostgreSql" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/issuer/SsiCredentialIssuer.Service/SsiCredentialIssuer.Service.csproj
+++ b/src/issuer/SsiCredentialIssuer.Service/SsiCredentialIssuer.Service.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/database/SsiCredentialIssuer.DbAccess.Tests/SsiCredentialIssuer.DbAccess.Tests.csproj
+++ b/tests/database/SsiCredentialIssuer.DbAccess.Tests/SsiCredentialIssuer.DbAccess.Tests.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.18.1" />
     <PackageReference Include="FakeItEasy" Version="7.4.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="2.3.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="3.4.0" />

--- a/tests/externalservices/Callback.Service.Tests/Callback.Service.Tests.csproj
+++ b/tests/externalservices/Callback.Service.Tests/Callback.Service.Tests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="FakeItEasy" Version="7.4.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.17" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="3.4.0" />
     <PackageReference Include="xunit" Version="2.5.0" />

--- a/tests/externalservices/Portal.Service.Tests/Portal.Service.Tests.csproj
+++ b/tests/externalservices/Portal.Service.Tests/Portal.Service.Tests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="FakeItEasy" Version="7.4.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.17" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="3.4.0" />
     <PackageReference Include="xunit" Version="2.5.0" />

--- a/tests/externalservices/Wallet.Service.Tests/Wallet.Service.Tests.csproj
+++ b/tests/externalservices/Wallet.Service.Tests/Wallet.Service.Tests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="FakeItEasy" Version="7.4.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.17" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web" Version="2.3.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="3.4.0" />

--- a/tests/issuer/SsiCredentialIssuer.Service.Tests/SsiCredentialIssuer.Service.Tests.csproj
+++ b/tests/issuer/SsiCredentialIssuer.Service.Tests/SsiCredentialIssuer.Service.Tests.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="FakeItEasy" Version="7.4.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.17" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="3.4.0" />
     <PackageReference Include="xunit" Version="2.5.0" />


### PR DESCRIPTION
## Description

increase efcore version to latest 8.0.7

## Why

efcore 8.0.3 has transitive dependency System.Text.Json 8.0.0 which has a security-vulerability that is clasified as high. Upgrade to efcore 8.0.7 implicitly upgrades this dependency to System.Text.Json 8.0.4 which resolves the vulnerability.

## Issue

https://github.com/eclipse-tractusx/portal/issues/369

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes
