### PR TITLE
docs: add documentation for initial credential creation

### DIFF
--- a/charts/ssi-credential-issuer/README.md
+++ b/charts/ssi-credential-issuer/README.md
@@ -2,9 +2,9 @@
 
 This helm chart installs the Catena-X SSI Credential Issuer application.
 
-For further information please refer to [Technical Documentation](./docs/technical-documentation).
+For further information please refer to [Technical Documentation](/docs/technical-documentation).
 
-For further information about the initial credential creation for an operator please refer to [initial credential setup](./docs/operator-credential-creation/intial-credential-setup.md)
+For information about the initial credential creation for the Operator, please refer to [initial credential setup](/docs/technical-documentation/operator-credential-creation/initial-credential-setup.md)
 
 The referenced container images are for demonstration purposes only.
 

--- a/charts/ssi-credential-issuer/README.md
+++ b/charts/ssi-credential-issuer/README.md
@@ -4,6 +4,8 @@ This helm chart installs the Catena-X SSI Credential Issuer application.
 
 For further information please refer to [Technical Documentation](./docs/technical-documentation).
 
+For further information about the initial credential creation for an operator please refer to [initial credential setup](./docs/operator-credential-creation/intial-credential-setup.md)
+
 The referenced container images are for demonstration purposes only.
 
 ## Installation

--- a/charts/ssi-credential-issuer/README.md.gotmpl
+++ b/charts/ssi-credential-issuer/README.md.gotmpl
@@ -2,9 +2,9 @@
 
 This helm chart installs the Catena-X SSI Credential Issuer application.
 
-For further information please refer to [Technical Documentation](./docs/technical-documentation).
+For further information please refer to [Technical Documentation](/docs/technical-documentation).
 
-For further information about the initial credential creation for an operator please refer to [initial credential setup](./docs/operator-credential-creation/intial-credential-setup.md)
+For information about the initial credential creation for the Operator, please refer to [initial credential setup](/docs/technical-documentation/operator-credential-creation/initial-credential-setup.md)
 
 The referenced container images are for demonstration purposes only.
 

--- a/charts/ssi-credential-issuer/README.md.gotmpl
+++ b/charts/ssi-credential-issuer/README.md.gotmpl
@@ -4,6 +4,8 @@ This helm chart installs the Catena-X SSI Credential Issuer application.
 
 For further information please refer to [Technical Documentation](./docs/technical-documentation).
 
+For further information about the initial credential creation for an operator please refer to [initial credential setup](./docs/operator-credential-creation/intial-credential-setup.md)
+
 The referenced container images are for demonstration purposes only.
 
 ## Installation

--- a/docs/technical-documentation/operator-credential-creation/initial-credential-setup.md
+++ b/docs/technical-documentation/operator-credential-creation/initial-credential-setup.md
@@ -50,8 +50,7 @@ VALUES ('8ddd7518-4532-409e-920a-c2b5029408a7', 5, 1, 'your process id', now(), 
 
 ```
 
-**Warning**: Currently the application of the wallet must be set to `catena-x-portal`. This value is not configurable and must be existing in the wallet. This will be resolved in a later release.
-
+**Warning**: Currently the application of the wallet must be set to `catena-x-portal`. This value is not configurable and must be existing in the wallet (see [#226](https://github.com/eclipse-tractusx/ssi-credential-issuer/issues/226)).
 ## NOTICE
 
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/technical-documentation/operator-credential-creation/intial-credential-setup.md
+++ b/docs/technical-documentation/operator-credential-creation/intial-credential-setup.md
@@ -1,0 +1,59 @@
+# Initial Credential Setup
+
+After the initial wallet creation which is executed by the portal the process will create the bpn and membership credential.
+
+The portal will request a bpn credential via the endpoint `POST: api/issuer/bpn` which will create a process and a process step. The process will currently fail at step 4 since the issuer wallet is the same as the holder wallet. This will be fixed in the future. For now you can execute the following query to resolve the issue
+
+```sql
+
+SELECT process_id
+FROM issuer.company_ssi_details
+where bpnl = 'operator bpn'
+and verified_credential_type_id = 7
+
+```
+
+take the process id and insert it into the following query
+
+```sql
+
+UPDATE issuer.process_steps
+SET process_step_status_id=2
+WHERE process_step_type_id = 4 and process_step_status_id = 4;
+
+INSERT INTO issuer.process_steps(id, process_step_type_id, process_step_status_id, process_id, date_created, date_last_changed, message)
+VALUES ('8ddd7518-4532-409e-920a-c2b5029408a7', 5, 1, 'your process id', now(), null, null);
+
+```
+
+After that the issuer component will do the callback to the portal with the successfully created bpn credential. The portal will than request the creation of the membership credential via `POST: api/issuer/membership`. The same as for the bpn credential applies for the membership credential. The error can be fixed with the following queries
+
+```sql
+
+SELECT process_id
+FROM issuer.company_ssi_details
+where bpnl = 'operator bpn'
+and verified_credential_type_id = 4
+
+```
+
+take the process id and insert it into the following query
+
+```sql
+
+UPDATE issuer.process_steps
+SET process_step_status_id=2
+WHERE process_step_type_id = 4 and process_step_status_id = 4;
+
+INSERT INTO issuer.process_steps(id, process_step_type_id, process_step_status_id, process_id, date_created, date_last_changed, message)
+VALUES ('8ddd7518-4532-409e-920a-c2b5029408a7', 5, 1, 'your process id', now(), null, null);
+
+```
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/ssi-credential-issuer

--- a/docs/technical-documentation/operator-credential-creation/intial-credential-setup.md
+++ b/docs/technical-documentation/operator-credential-creation/intial-credential-setup.md
@@ -50,6 +50,8 @@ VALUES ('8ddd7518-4532-409e-920a-c2b5029408a7', 5, 1, 'your process id', now(), 
 
 ```
 
+**Warning**: Currently the application of the wallet must be set to `catena-x-portal`. This value is not configurable and must be existing in the wallet. This will be resolved in a later release.
+
 ## NOTICE
 
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
## Description

Adding documentation for the initial credential creation for the operator

## Why

to give an overview of the initial credential creation process

## Issue

Refs: #206

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
