### PR TITLE
fix(document): adjust validation to allow the issuer to display documents of credentials

### DIFF
--- a/src/database/SsiCredentialIssuer.DbAccess/Repositories/CredentialRepository.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Repositories/CredentialRepository.cs
@@ -111,7 +111,7 @@ public class CredentialRepository(IssuerDbContext dbContext) : ICredentialReposi
             .Where(x => x.Id == documentId)
             .Select(x => new ValueTuple<bool, bool, string, DocumentStatusId, byte[], MediaTypeId>(
                 true,
-                x.CompanySsiDetails.Any(c => c.Bpnl == bpnl),
+                x.CompanySsiDetails.Any(c => c.Bpnl == bpnl || c.IssuerBpn == bpnl),
                 x.DocumentName,
                 x.DocumentStatusId,
                 x.DocumentContent,

--- a/tests/database/SsiCredentialIssuer.DbAccess.Tests/CredentialRepositoryTests.cs
+++ b/tests/database/SsiCredentialIssuer.DbAccess.Tests/CredentialRepositoryTests.cs
@@ -244,6 +244,21 @@ public class CredentialRepositoryTests : IAssemblyFixture<TestDbFixture>
     }
 
     [Fact]
+    public async Task GetDocumentById_WithIssuerBpn_ReturnsExpected()
+    {
+        // Arrange
+        var sut = await CreateSut();
+
+        // Act
+        var result = await sut.GetDocumentById(new Guid("e020787d-1e04-4c0b-9c06-bd1cd44724b1"), "BPNL000003ISSUER");
+
+        // Assert
+        result.Exists.Should().BeTrue();
+        result.IsSameCompany.Should().BeTrue();
+        result.MediaTypeId.Should().Be(MediaTypeId.PNG);
+    }
+
+    [Fact]
     public async Task GetDocumentById_WithWrongBpn_ReturnsExpected()
     {
         // Arrange


### PR DESCRIPTION
## Description

Adjust the validation of endpoint GET: api/credential/documents/{documentId} to allow the issuer to display document of the requester.

## Why

The issuer is not able to display the requested credential documents.

## Issue

Refs: #225

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
