### PR TITLE
feat(notification): adjust notification request parameter

### DIFF
--- a/src/externalservices/Portal.Service/Models/NotificationRequest.cs
+++ b/src/externalservices/Portal.Service/Models/NotificationRequest.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 namespace Org.Eclipse.TractusX.SsiCredentialIssuer.Portal.Service.Models;
 
 public record NotificationRequest(
-    [property: JsonPropertyName("requester")] Guid Requester,
+    [property: JsonPropertyName("receiver")] Guid Receiver,
     [property: JsonPropertyName("content")] string Content,
     [property: JsonPropertyName("notificationTypeId")] NotificationTypeId NotificationTypeId
 );

--- a/src/externalservices/Portal.Service/Services/IPortalService.cs
+++ b/src/externalservices/Portal.Service/Services/IPortalService.cs
@@ -23,6 +23,6 @@ namespace Org.Eclipse.TractusX.SsiCredentialIssuer.Portal.Service.Services;
 
 public interface IPortalService
 {
-    Task AddNotification(string content, Guid requester, NotificationTypeId notificationTypeId, CancellationToken cancellationToken);
+    Task AddNotification(string content, Guid receiver, NotificationTypeId notificationTypeId, CancellationToken cancellationToken);
     Task TriggerMail(string template, Guid requester, IEnumerable<MailParameter> mailParameters, CancellationToken cancellationToken);
 }

--- a/src/externalservices/Portal.Service/Services/PortalService.cs
+++ b/src/externalservices/Portal.Service/Services/PortalService.cs
@@ -39,10 +39,10 @@ public class PortalService(ITokenService tokenService, IOptions<PortalSettings> 
 
     private readonly PortalSettings _settings = options.Value;
 
-    public async Task AddNotification(string content, Guid requester, NotificationTypeId notificationTypeId, CancellationToken cancellationToken)
+    public async Task AddNotification(string content, Guid receiver, NotificationTypeId notificationTypeId, CancellationToken cancellationToken)
     {
         using var client = await tokenService.GetAuthorizedClient<PortalService>(_settings, cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
-        var data = new NotificationRequest(requester, content, notificationTypeId);
+        var data = new NotificationRequest(receiver, content, notificationTypeId);
         await client.PostAsJsonAsync("api/notification/ssi-credentials", data, Options, cancellationToken)
             .CatchingIntoServiceExceptionFor("notification", HttpAsyncResponseMessageExtension.RecoverOptions.REQUEST_EXCEPTION,
         async x => (false, await x.Content.ReadAsStringAsync().ConfigureAwait(ConfigureAwaitOptions.None)))

--- a/tests/externalservices/Portal.Service.Tests/PortalServiceTests.cs
+++ b/tests/externalservices/Portal.Service.Tests/PortalServiceTests.cs
@@ -70,7 +70,7 @@ public class PortalServiceTests
     public async Task AddNotification_WithValid_DoesNotThrowException()
     {
         // Arrange
-        var requester = Guid.NewGuid();
+        var receiver = Guid.NewGuid();
         var httpMessageHandlerMock =
             new HttpMessageHandlerMock(HttpStatusCode.OK);
         using var httpClient = new HttpClient(httpMessageHandlerMock);
@@ -80,14 +80,14 @@ public class PortalServiceTests
         var sut = new PortalService(_tokenService, _options);
 
         // Act
-        await sut.AddNotification("Test", requester, NotificationTypeId.CREDENTIAL_APPROVAL, CancellationToken.None);
+        await sut.AddNotification("Test", receiver, NotificationTypeId.CREDENTIAL_APPROVAL, CancellationToken.None);
 
         // Assert
         httpMessageHandlerMock.RequestMessage.Should().Match<HttpRequestMessage>(x =>
             x.Content is JsonContent &&
             (x.Content as JsonContent)!.ObjectType == typeof(NotificationRequest) &&
             ((x.Content as JsonContent)!.Value as NotificationRequest)!.Content == "Test" &&
-            ((x.Content as JsonContent)!.Value as NotificationRequest)!.Receiver == requester &&
+            ((x.Content as JsonContent)!.Value as NotificationRequest)!.Receiver == receiver &&
             ((x.Content as JsonContent)!.Value as NotificationRequest)!.NotificationTypeId == NotificationTypeId.CREDENTIAL_APPROVAL
         );
     }
@@ -100,7 +100,7 @@ public class PortalServiceTests
     public async Task AddNotification_WithConflict_ThrowsServiceExceptionWithErrorContent(HttpStatusCode statusCode, string? content, string message)
     {
         // Arrange
-        var requester = Guid.NewGuid();
+        var receiver = Guid.NewGuid();
         var httpMessageHandlerMock = content == null
             ? new HttpMessageHandlerMock(statusCode)
             : new HttpMessageHandlerMock(statusCode, new StringContent(content));
@@ -110,7 +110,7 @@ public class PortalServiceTests
         var sut = new PortalService(_tokenService, _options);
 
         // Act
-        async Task Act() => await sut.AddNotification("Test", requester, NotificationTypeId.CREDENTIAL_APPROVAL, CancellationToken.None);
+        async Task Act() => await sut.AddNotification("Test", receiver, NotificationTypeId.CREDENTIAL_APPROVAL, CancellationToken.None);
 
         // Assert
         var ex = await Assert.ThrowsAsync<ServiceException>(Act);

--- a/tests/externalservices/Portal.Service.Tests/PortalServiceTests.cs
+++ b/tests/externalservices/Portal.Service.Tests/PortalServiceTests.cs
@@ -87,7 +87,7 @@ public class PortalServiceTests
             x.Content is JsonContent &&
             (x.Content as JsonContent)!.ObjectType == typeof(NotificationRequest) &&
             ((x.Content as JsonContent)!.Value as NotificationRequest)!.Content == "Test" &&
-            ((x.Content as JsonContent)!.Value as NotificationRequest)!.Requester == requester &&
+            ((x.Content as JsonContent)!.Value as NotificationRequest)!.Receiver == requester &&
             ((x.Content as JsonContent)!.Value as NotificationRequest)!.NotificationTypeId == NotificationTypeId.CREDENTIAL_APPROVAL
         );
     }


### PR DESCRIPTION
## Description

Adjust the request parameter to create notifications

## Why

The portal backend changed the request structure to create notifications

## Issue

Refs: https://github.com/eclipse-tractusx/portal-backend/issues/812

## Corresponding Backend PR 

https://github.com/eclipse-tractusx/portal-backend/pull/906

## Corresponding Iam PR

https://github.com/eclipse-tractusx/portal-iam/pull/169

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
