### PR TITLE
feat(ssi): enhanced the owned-credentials endpoint

### DIFF
--- a/src/database/SsiCredentialIssuer.DbAccess/Models/OwnedVerifiedCredentialData.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Models/OwnedVerifiedCredentialData.cs
@@ -26,5 +26,6 @@ public record OwnedVerifiedCredentialData(
     VerifiedCredentialTypeId CredentialType,
     CompanySsiDetailStatusId Status,
     DateTimeOffset? ExpiryDate,
-    string Authority
+    string Authority,
+    string? Version
 );

--- a/src/database/SsiCredentialIssuer.DbAccess/Repositories/CompanySsiDetailsRepository.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Repositories/CompanySsiDetailsRepository.cs
@@ -175,7 +175,8 @@ public class CompanySsiDetailsRepository(IssuerDbContext context)
                 c.VerifiedCredentialTypeId,
                 c.CompanySsiDetailStatusId,
                 c.ExpiryDate,
-                c.IssuerBpn))
+                c.IssuerBpn,
+                c.VerifiedCredentialExternalTypeDetailVersion!.Version))
             .ToAsyncEnumerable();
 
     /// <inheritdoc />

--- a/tests/issuer/SsiCredentialIssuer.Service.Tests/BusinessLogic/IssuerBusinessLogicTests.cs
+++ b/tests/issuer/SsiCredentialIssuer.Service.Tests/BusinessLogic/IssuerBusinessLogicTests.cs
@@ -989,4 +989,50 @@ public class IssuerBusinessLogicTests
     }
 
     #endregion
+
+    #region GetCredentialsForBpn
+
+    [Fact]
+    public async void GetCredentialsForBpn_WithVersion_ReturnExpected()
+    {
+        OwnedVerifiedCredentialData[] ownedVerifiedCredentialData = [new OwnedVerifiedCredentialData(
+            Guid.NewGuid(),
+            VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK,
+            CompanySsiDetailStatusId.ACTIVE,
+            DateTimeOffset.Now,
+            "Test Authority",
+            "3.0")];
+
+        A.CallTo(() => _companySsiDetailsRepository.GetOwnCredentialDetails(_identity.Bpnl)).Returns(ownedVerifiedCredentialData.ToAsyncEnumerable());
+
+        var ownedCredentials = _sut.GetCredentialsForBpn();
+
+        await foreach (var credentialData in ownedCredentials)
+        {
+            credentialData.Version.Should().Be(ownedVerifiedCredentialData[0].Version);
+        }
+    }
+
+    [Fact]
+    public async void GetCredentialsForBpn_WithoutVersion_ReturnExpected()
+    {
+        OwnedVerifiedCredentialData[] ownedVerifiedCredentialData = [new OwnedVerifiedCredentialData(
+            Guid.NewGuid(),
+            VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK,
+            CompanySsiDetailStatusId.ACTIVE,
+            DateTimeOffset.Now,
+            "Test Authority",
+            null)];
+
+        A.CallTo(() => _companySsiDetailsRepository.GetOwnCredentialDetails(_identity.Bpnl)).Returns(ownedVerifiedCredentialData.ToAsyncEnumerable());
+
+        var ownedCredentials = _sut.GetCredentialsForBpn();
+
+        await foreach (var credentialData in ownedCredentials)
+        {
+            credentialData.Version.Should().BeNull();
+        }
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Description

We need to enhance the API response body by including a version attribute for API Path: GET /api/issuer/owned-credentials. 

## Why

For better traceability and version control.

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes

