### PR TITLE
fix: adjust create credential request structure

### DIFF
--- a/src/externalservices/Wallet.Service/Models/CreateCredentialResponse.cs
+++ b/src/externalservices/Wallet.Service/Models/CreateCredentialResponse.cs
@@ -24,11 +24,15 @@ namespace Org.Eclipse.TractusX.SsiCredentialIssuer.Wallet.Service.Models;
 
 public record CreateSignedCredentialRequest(
     [property: JsonPropertyName("application")] string Application,
-    [property: JsonPropertyName("payload")] CreateSignedPayload Payload
+    [property: JsonPropertyName("payload")] IssueWithSignature Issue
+);
+
+public record IssueWithSignature(
+    [property: JsonPropertyName("issueWithSignature")] CreateSignedPayload Payload
 );
 
 public record CreateSignedPayload(
-    [property: JsonPropertyName("content")] JsonDocument Issue,
+    [property: JsonPropertyName("content")] JsonDocument Content,
     [property: JsonPropertyName("signature")] SignData Signature
 );
 

--- a/src/externalservices/Wallet.Service/Services/WalletService.cs
+++ b/src/externalservices/Wallet.Service/Services/WalletService.cs
@@ -41,7 +41,7 @@ public class WalletService(
     public async Task<CreateSignedCredentialResponse> CreateSignedCredential(JsonDocument payload, CancellationToken cancellationToken)
     {
         using var client = await basicAuthTokenService.GetBasicAuthorizedClient<WalletService>(_settings, cancellationToken);
-        var data = new CreateSignedCredentialRequest(_settings.WalletApplication, new CreateSignedPayload(payload, new SignData("external", "jwt", null)));
+        var data = new CreateSignedCredentialRequest(_settings.WalletApplication, new IssueWithSignature(new CreateSignedPayload(payload, new SignData("external", "jwt", null))));
         var result = await client.PostAsJsonAsync(_settings.CreateSignedCredentialPath, data, Options, cancellationToken)
             .CatchingIntoServiceExceptionFor("create-credential", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE,
                 async x => (false, await x.Content.ReadAsStringAsync().ConfigureAwait(ConfigureAwaitOptions.None)))

--- a/tests/externalservices/Wallet.Service.Tests/Services/WalletServiceTests.cs
+++ b/tests/externalservices/Wallet.Service.Tests/Services/WalletServiceTests.cs
@@ -73,10 +73,10 @@ public class WalletServiceTests
             x.Content is JsonContent &&
             (x.Content as JsonContent)!.ObjectType == typeof(CreateSignedCredentialRequest) &&
             ((x.Content as JsonContent)!.Value as CreateSignedCredentialRequest)!.Application == "catena-x-portal" &&
-            ((x.Content as JsonContent)!.Value as CreateSignedCredentialRequest)!.Payload.Signature.ProofMechanism == "external" &&
-            ((x.Content as JsonContent)!.Value as CreateSignedCredentialRequest)!.Payload.Signature.ProofType == "jwt" &&
-            ((x.Content as JsonContent)!.Value as CreateSignedCredentialRequest)!.Payload.Signature.KeyName == null &&
-            ((x.Content as JsonContent)!.Value as CreateSignedCredentialRequest)!.Payload.Issue == payload
+            ((x.Content as JsonContent)!.Value as CreateSignedCredentialRequest)!.Issue.Payload.Signature.ProofMechanism == "external" &&
+            ((x.Content as JsonContent)!.Value as CreateSignedCredentialRequest)!.Issue.Payload.Signature.ProofType == "jwt" &&
+            ((x.Content as JsonContent)!.Value as CreateSignedCredentialRequest)!.Issue.Payload.Signature.KeyName == null &&
+            ((x.Content as JsonContent)!.Value as CreateSignedCredentialRequest)!.Issue.Payload.Content == payload
         );
         result.Should().BeOfType<CreateSignedCredentialResponse>().Which.Id.Should().Be(id);
     }


### PR DESCRIPTION
## Description

Adjusting the credential request structure

## Why

The current structure is not matching the expected structure

Introduced in 1.2.0-alpha.1, no stable version affected

## Issue

Refs: #265

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-usxng-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
