### PR TITLE
chore: rename migrations

### DIFF
--- a/src/database/SsiCredentialIssuer.Migrations/Migrations/20240923070946_1.2.0-alpha.1.Designer.cs
+++ b/src/database/SsiCredentialIssuer.Migrations/Migrations/20240923070946_1.2.0-alpha.1.Designer.cs
@@ -32,8 +32,8 @@ using Org.Eclipse.TractusX.SsiCredentialIssuer.Entities;
 namespace Org.Eclipse.TractusX.SsiCredentialIssuer.Migrations.Migrations
 {
     [DbContext(typeof(IssuerDbContext))]
-    [Migration("20240923070946_2.0.0-alpha.1")]
-    partial class _200alpha1
+    [Migration("20240923070946_1.2.0-alpha.1")]
+    partial class _120alpha1
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/src/database/SsiCredentialIssuer.Migrations/Migrations/20240923070946_1.2.0-alpha.1.cs
+++ b/src/database/SsiCredentialIssuer.Migrations/Migrations/20240923070946_1.2.0-alpha.1.cs
@@ -24,7 +24,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace Org.Eclipse.TractusX.SsiCredentialIssuer.Migrations.Migrations
 {
     /// <inheritdoc />
-    public partial class _200alpha1 : Migration
+    public partial class _120alpha1 : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/src/database/SsiCredentialIssuer.Migrations/Migrations/20241010142309_1.2.0-alpha.2.Designer.cs
+++ b/src/database/SsiCredentialIssuer.Migrations/Migrations/20241010142309_1.2.0-alpha.2.Designer.cs
@@ -32,8 +32,8 @@ using Org.Eclipse.TractusX.SsiCredentialIssuer.Entities;
 namespace Org.Eclipse.TractusX.SsiCredentialIssuer.Migrations.Migrations
 {
     [DbContext(typeof(IssuerDbContext))]
-    [Migration("20240924092944_209-AddRetrigger")]
-    partial class _209AddRetrigger
+    [Migration("20241010142309_1.2.0-alpha.2")]
+    partial class _120alpha2
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/src/database/SsiCredentialIssuer.Migrations/Migrations/20241010142309_1.2.0-alpha.2.cs
+++ b/src/database/SsiCredentialIssuer.Migrations/Migrations/20241010142309_1.2.0-alpha.2.cs
@@ -26,7 +26,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace Org.Eclipse.TractusX.SsiCredentialIssuer.Migrations.Migrations
 {
     /// <inheritdoc />
-    public partial class _209AddRetrigger : Migration
+    public partial class _120alpha2 : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)


### PR DESCRIPTION
## Description

rename migrations due to release of new version and one wrongly named 2.0.0-alpha.1 in course of https://github.com/eclipse-tractusx/ssi-credential-issuer/pull/257

## Why

https://github.com/eclipse-tractusx/ssi-credential-issuer/issues/271
https://github.com/eclipse-tractusx/ssi-credential-issuer/issues/272

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own changes
