### PR TITLE
build: add stable env configuration file

### DIFF
--- a/environments/argocd-app-templates/appsetup-stable.yaml
+++ b/environments/argocd-app-templates/appsetup-stable.yaml
@@ -1,0 +1,38 @@
+###############################################################
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ssi-credential-issuer
+spec:
+  destination:
+    namespace: product-portal
+    server: 'https://kubernetes.default.svc'
+  source:
+    path: charts/ssi-credential-issuer
+    repoURL: 'https://github.com/eclipse-tractusx/ssi-credential-issuer.git'
+    targetRevision: ssi-credential-issuer-1.2.0-alpha.1
+    plugin:
+      env:
+        - name: AVP_SECRET
+          value: vault-secret
+        - name: helm_args
+          value: '-f values.yaml -f ../../environments/helm-values/values-stable.yaml'
+  project: project-portal

--- a/environments/helm-values/values-stable.yaml
+++ b/environments/helm-values/values-stable.yaml
@@ -53,7 +53,7 @@ service:
         encryptionKey: "<path:portal/data/ssi-credential-issuer/stable/credential#encryptionKey0>"
   portal:
     clientId: "<path:portal/data/ssi-credential-issuer/portal#clientId>"
-    clientSecret: "<path:portal/data/int/iam/centralidp-client-secrets#issuer-sa>"
+    clientSecret: "<path:portal/data/stable/iam/centralidp-client-secrets#issuer-sa>"
 
 migrations:
   logging:

--- a/environments/helm-values/values-stable.yaml
+++ b/environments/helm-values/values-stable.yaml
@@ -1,0 +1,88 @@
+###############################################################
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+portalBackendAddress: "https://portal-backend.stable.catena-x.net"
+walletAddress: "https://dis-integration-service-prod.eu10.dim.cloud.sap"
+walletTokenAddress: "https://issuer.authentication.eu10.hana.ondemand.com/oauth/token"
+
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "8m"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://*.stable.catena-x.net"
+  tls:
+    - secretName: "ssi-credential-issuer.stable.catena-x.net-tls"
+      hosts:
+        - "ssi-credential-issuer.stable.catena-x.net"
+  hosts:
+    - host: "ssi-credential-issuer.stable.catena-x.net"
+      paths:
+        - path: "/api"
+          pathType: "Prefix"
+          backend:
+            port: 8080
+
+service:
+  swaggerEnabled: true
+  credential:
+    issuerDid: "did:web:portal-backend.stable.catena-x.net:api:administration:staticdata:did:BPNL00000003CRHK"
+    issuerBpn: "BPNL00000003CRHK"
+    statusListUrl: "https://dim-static-prod.dis-cloud-prod.cfapps.eu10-004.hana.ondemand.com/credentials/status/ba0cd4ef-63e0-4c13-829a-915c496dc836/3c7b17d8-fe44-4f08-9bf9-f786f8be73bf"
+    encryptionConfigs:
+      index0:
+        encryptionKey: "<path:portal/data/ssi-credential-issuer/stable/credential#encryptionKey0>"
+  portal:
+    clientId: "<path:portal/data/ssi-credential-issuer/portal#clientId>"
+    clientSecret: "<path:portal/data/int/iam/centralidp-client-secrets#issuer-sa>"
+
+migrations:
+  logging:
+    default: "Debug"
+
+processesworker:
+  logging:
+    default: "Debug"
+  portal:
+    clientId: "<path:portal/data/ssi-credential-issuer/portal#clientId>"
+    clientSecret: "<path:portal/data/stable/iam/centralidp-client-secrets#issuer-sa>"
+  wallet:
+    clientId: "<path:portal/data/ssi-credential-issuer/stable/wallet#clientId>"
+    clientSecret: "<path:portal/data/ssi-credential-issuer/stable/wallet#clientSecret>"
+
+credentialExpiry:
+  logging:
+    default: "Debug"
+
+centralidp:
+  address: "https://centralidp.stable.catena-x.net"
+  jwtBearerOptions:
+    tokenValidationParameters:
+      validAudience: "Cl24-CX-SSI-CredentialIssuer"
+
+replicaCount: 2
+
+postgresql:
+  architecture: standalone
+  auth:
+    postgrespassword: "<path:portal/data/ssi-credential-issuer/stable/postgres#postgres-password>"
+    password: "<path:portal/data/ssi-credential-issuer/stable/postgres#password>"


### PR DESCRIPTION
## Description

A new values.yaml for the stable configuration was added similar to values-int.yaml.

## Why

With the new stable environment a specific values.yaml is necessary for the deployment of the service. 

## Issue

Relates to https://github.com/eclipse-tractusx/portal/issues/408

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
