### PR TITLE
feat: skip credential import if holder equals issuer

### DIFF
--- a/src/database/SsiCredentialIssuer.DbAccess/Repositories/CredentialRepository.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Repositories/CredentialRepository.cs
@@ -28,15 +28,11 @@ namespace Org.Eclipse.TractusX.SsiCredentialIssuer.DBAccess.Repositories;
 
 public class CredentialRepository(IssuerDbContext dbContext) : ICredentialRepository
 {
-    public Task<Guid?> GetWalletCredentialId(Guid credentialId) =>
-        dbContext.CompanySsiDetails.Where(x => x.Id == credentialId)
-            .Select(x => x.ExternalCredentialId)
-            .SingleOrDefaultAsync();
-
-    public Task<(HolderWalletData HolderWalletData, string? Credential, EncryptionTransformationData EncryptionInformation, string? CallbackUrl)> GetCredentialData(Guid credentialId) =>
+    public Task<(bool IsIssuerCompany, HolderWalletData HolderWalletData, string? Credential, EncryptionTransformationData EncryptionInformation, string? CallbackUrl)> GetCredentialData(Guid credentialId) =>
         dbContext.CompanySsiDetails
             .Where(x => x.Id == credentialId)
-            .Select(x => new ValueTuple<HolderWalletData, string?, EncryptionTransformationData, string?>(
+            .Select(x => new ValueTuple<bool, HolderWalletData, string?, EncryptionTransformationData, string?>(
+                x.Bpnl == x.IssuerBpn,
                 new HolderWalletData(x.CompanySsiProcessData!.HolderWalletUrl, x.CompanySsiProcessData.ClientId),
                 x.Credential,
                 new EncryptionTransformationData(x.CompanySsiProcessData!.ClientSecret, x.CompanySsiProcessData.InitializationVector, x.CompanySsiProcessData.EncryptionMode),

--- a/src/database/SsiCredentialIssuer.DbAccess/Repositories/ICredentialRepository.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Repositories/ICredentialRepository.cs
@@ -26,8 +26,7 @@ namespace Org.Eclipse.TractusX.SsiCredentialIssuer.DBAccess.Repositories;
 
 public interface ICredentialRepository
 {
-    Task<Guid?> GetWalletCredentialId(Guid credentialId);
-    Task<(HolderWalletData HolderWalletData, string? Credential, EncryptionTransformationData EncryptionInformation, string? CallbackUrl)> GetCredentialData(Guid credentialId);
+    Task<(bool IsIssuerCompany, HolderWalletData HolderWalletData, string? Credential, EncryptionTransformationData EncryptionInformation, string? CallbackUrl)> GetCredentialData(Guid credentialId);
     Task<(bool Exists, Guid CredentialId)> GetDataForProcessId(Guid processId);
     Task<(VerifiedCredentialTypeKindId CredentialTypeKindId, JsonDocument Schema)> GetCredentialStorageInformationById(Guid credentialId);
     Task<(Guid? ExternalCredentialId, VerifiedCredentialTypeKindId KindId, bool HasEncryptionInformation, string? CallbackUrl)> GetExternalCredentialAndKindId(Guid credentialId);

--- a/src/externalservices/Wallet.Service/BusinessLogic/IWalletBusinessLogic.cs
+++ b/src/externalservices/Wallet.Service/BusinessLogic/IWalletBusinessLogic.cs
@@ -26,6 +26,8 @@ namespace Org.Eclipse.TractusX.SsiCredentialIssuer.Wallet.Service.BusinessLogic;
 public interface IWalletBusinessLogic
 {
     Task CreateSignedCredential(Guid companySsiDetailId, JsonDocument schema, CancellationToken cancellationToken);
+
     Task CreateCredentialForHolder(Guid companySsiDetailId, string holderWalletUrl, string clientId, EncryptionInformation encryptionInformation, string credential, CancellationToken cancellationToken);
+
     Task GetCredential(Guid credentialId, Guid externalCredentialId, VerifiedCredentialTypeKindId kindId, CancellationToken cancellationToken);
 }

--- a/tests/database/SsiCredentialIssuer.DbAccess.Tests/CredentialRepositoryTests.cs
+++ b/tests/database/SsiCredentialIssuer.DbAccess.Tests/CredentialRepositoryTests.cs
@@ -85,23 +85,6 @@ public class CredentialRepositoryTests : IAssemblyFixture<TestDbFixture>
 
     #endregion
 
-    #region GetWalletCredentialId
-
-    [Fact]
-    public async Task GetWalletCredentialId_ReturnsExpectedDocument()
-    {
-        // Arrange
-        var sut = await CreateSut();
-
-        // Act
-        var result = await sut.GetWalletCredentialId(new Guid("9f5b9934-4014-4099-91e9-7b1aee696b03"));
-
-        // Assert
-        result.Should().Be(new Guid("bd474c60-e7ce-450f-bdf4-73604546fc5e"));
-    }
-
-    #endregion
-
     #region GetCredentialStorageInformationById
 
     [Fact]


### PR DESCRIPTION
## Description

* check if the holder equals the issuer, if so skip the import credential for holder step

## Why

Currently the process step fails because the credential is already in the wallet

## Issue

Refs: #250

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
