### PR TITLE
build: rename migrations for rc.1

### DIFF
--- a/src/database/SsiCredentialIssuer.Migrations/Migrations/20241021072243_1.2.0-rc.1.Designer.cs
+++ b/src/database/SsiCredentialIssuer.Migrations/Migrations/20241021072243_1.2.0-rc.1.Designer.cs
@@ -32,8 +32,8 @@ using Org.Eclipse.TractusX.SsiCredentialIssuer.Entities;
 namespace Org.Eclipse.TractusX.SsiCredentialIssuer.Migrations.Migrations
 {
     [DbContext(typeof(IssuerDbContext))]
-    [Migration("20241010142309_1.2.0-alpha.2")]
-    partial class _120alpha2
+    [Migration("20241021072243_1.2.0-rc.1")]
+    partial class _120rc1
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/src/database/SsiCredentialIssuer.Migrations/Migrations/20241021072243_1.2.0-rc.1.cs
+++ b/src/database/SsiCredentialIssuer.Migrations/Migrations/20241021072243_1.2.0-rc.1.cs
@@ -26,7 +26,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace Org.Eclipse.TractusX.SsiCredentialIssuer.Migrations.Migrations
 {
     /// <inheritdoc />
-    public partial class _120alpha2 : Migration
+    public partial class _120rc1 : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)


### PR DESCRIPTION
## Description

Rename the migration for alpha.2 to rc.1

## Why

The release is now feature complete thus no new migration will be created

## Issue

Refs: #272

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
