### PR TITLE
fix: set credential to active only after credential exists

### DIFF
--- a/src/externalservices/Wallet.Service/BusinessLogic/WalletBusinessLogic.cs
+++ b/src/externalservices/Wallet.Service/BusinessLogic/WalletBusinessLogic.cs
@@ -50,6 +50,7 @@ public class WalletBusinessLogic(
             c.Credential = null;
         }, c =>
         {
+            c.CompanySsiDetailStatusId = CompanySsiDetailStatusId.ACTIVE;
             c.ExternalCredentialId = credential.Id;
             c.Credential = credential.Jwt;
         });

--- a/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
@@ -160,13 +160,11 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
         UpdateIssuanceDate(credentialId, data, companySsiRepository);
         companySsiRepository.AttachAndModifyCompanySsiDetails(credentialId, c =>
             {
-                c.CompanySsiDetailStatusId = data.Status;
                 c.ExpiryDate = DateTimeOffset.MinValue;
                 c.ProcessId = null;
             },
             c =>
             {
-                c.CompanySsiDetailStatusId = CompanySsiDetailStatusId.ACTIVE;
                 c.DateLastChanged = _dateTimeProvider.OffsetNow;
                 c.ExpiryDate = expiry;
                 c.ProcessId = processId;

--- a/tests/externalservices/Wallet.Service.Tests/BusinessLogic/WalletBusinessLogicTests.cs
+++ b/tests/externalservices/Wallet.Service.Tests/BusinessLogic/WalletBusinessLogicTests.cs
@@ -74,7 +74,7 @@ public class WalletBusinessLogicTests
         var id = Guid.NewGuid();
         var externalId = Guid.NewGuid();
         var schema = JsonDocument.Parse("{}");
-        var ssiDetail = new CompanySsiDetail(id, null!, VerifiedCredentialTypeId.BUSINESS_PARTNER_NUMBER, CompanySsiDetailStatusId.ACTIVE, IssuerBpnl, Guid.NewGuid().ToString(), DateTimeOffset.UtcNow);
+        var ssiDetail = new CompanySsiDetail(id, null!, VerifiedCredentialTypeId.BUSINESS_PARTNER_NUMBER, CompanySsiDetailStatusId.PENDING, IssuerBpnl, Guid.NewGuid().ToString(), DateTimeOffset.UtcNow);
         A.CallTo(() => _companySsiDetailRepository.AttachAndModifyCompanySsiDetails(A<Guid>._, A<Action<CompanySsiDetail>>._, A<Action<CompanySsiDetail>>._))
             .Invokes((Guid _, Action<CompanySsiDetail>? initialize, Action<CompanySsiDetail> setupOptionalFields) =>
             {
@@ -94,6 +94,7 @@ public class WalletBusinessLogicTests
             .MustHaveHappenedOnceExactly();
         ssiDetail.ExternalCredentialId.Should().Be(externalId);
         ssiDetail.Credential.Should().Be("cred");
+        ssiDetail.CompanySsiDetailStatusId.Should().Be(CompanySsiDetailStatusId.ACTIVE);
     }
 
     #endregion

--- a/tests/issuer/SsiCredentialIssuer.Service.Tests/BusinessLogic/IssuerBusinessLogicTests.cs
+++ b/tests/issuer/SsiCredentialIssuer.Service.Tests/BusinessLogic/IssuerBusinessLogicTests.cs
@@ -408,7 +408,6 @@ public class IssuerBusinessLogicTests
         A.CallTo(() => _processStepRepository.CreateProcess(ProcessTypeId.CREATE_CREDENTIAL))
             .MustHaveHappenedOnceExactly();
 
-        detail.CompanySsiDetailStatusId.Should().Be(CompanySsiDetailStatusId.ACTIVE);
         detail.DateLastChanged.Should().Be(now);
         processData.Schema.Deserialize<FrameworkCredential>()!.IssuanceDate.Should().Be(now);
     }
@@ -465,7 +464,6 @@ public class IssuerBusinessLogicTests
         A.CallTo(() => _processStepRepository.CreateProcess(ProcessTypeId.CREATE_CREDENTIAL))
             .MustHaveHappenedOnceExactly();
 
-        detail.CompanySsiDetailStatusId.Should().Be(CompanySsiDetailStatusId.ACTIVE);
         detail.DateLastChanged.Should().Be(now);
         processData.Schema.Deserialize<FrameworkCredential>()!.IssuanceDate.Should().Be(now);
     }


### PR DESCRIPTION
## Description

The credential is set to active only after it was created in the wallet

## Why

To have the correct state when the credential isn't created yet

## Issue

Refs: #285

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
