### PR TITLE
feat: make statuslist type configureable

### DIFF
--- a/charts/ssi-credential-issuer/templates/deployment-issuer-service.yaml
+++ b/charts/ssi-credential-issuer/templates/deployment-issuer-service.yaml
@@ -122,6 +122,8 @@ spec:
           value: "{{ .Values.service.credential.issuerBpn }}"
         - name: "CREDENTIAL__STATUSLISTURL"
           value: "{{ .Values.service.credential.statusListUrl }}"
+        - name: "CREDENTIAL__STATUSLISTTYPE"
+          value: "{{ .Values.service.credential.statusListType }}"
         - name: "CREDENTIAL__ENCRYPTIONCONFIG__ENCRYPTIONCONFIGINDEX"
           value: "{{ .Values.service.credential.encryptionConfigIndex }}"
         - name: "CREDENTIAL__ENCRYPTIONCONFIGS__0__INDEX"

--- a/charts/ssi-credential-issuer/values.yaml
+++ b/charts/ssi-credential-issuer/values.yaml
@@ -61,6 +61,9 @@ service:
     issuerDid: "did:web:example"
     issuerBpn: "BPNL00000001TEST"
     statusListUrl: "https://example.org/statuslist"
+    # -- Type of the status list that is referenced unter statusListUrl
+    # -- valid types are:  StatusList2021, BitstringStatusList
+    statusListType: "StatusList2021"
     encryptionConfigIndex: 0
     encryptionConfigs:
       index0:

--- a/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
@@ -47,7 +47,6 @@ namespace Org.Eclipse.TractusX.SsiCredentialIssuer.Service.BusinessLogic;
 
 public class IssuerBusinessLogic : IIssuerBusinessLogic
 {
-    private const string StatusList = "StatusList2021";
     private static readonly JsonSerializerOptions Options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
     private static readonly IEnumerable<string> Context = new[] { "https://www.w3.org/2018/credentials/v1", "https://w3id.org/catenax/credentials/v1.0.0" };
     private static readonly Regex UrlPathInvalidCharsRegex = new("""[""<>#%{}|\\^~\[\]`]+""", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
@@ -355,7 +354,7 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
             ),
             new CredentialStatus(
                 _settings.StatusListUrl,
-                StatusList)
+                _settings.StatusListType)
         );
         var schema = JsonSerializer.Serialize(schemaData, Options);
         return await HandleCredentialProcessCreation(requestData.BusinessPartnerNumber, VerifiedCredentialTypeKindId.BPN, VerifiedCredentialTypeId.BUSINESS_PARTNER_NUMBER, expiryDate, schema, requestData.TechnicalUserDetails, null, requestData.CallbackUrl, companyCredentialDetailsRepository);
@@ -383,7 +382,7 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
             ),
             new CredentialStatus(
                 _settings.StatusListUrl,
-                StatusList)
+                _settings.StatusListType)
         );
         var schema = JsonSerializer.Serialize(schemaData, Options);
         return await HandleCredentialProcessCreation(requestData.HolderBpn, VerifiedCredentialTypeKindId.MEMBERSHIP, VerifiedCredentialTypeId.MEMBERSHIP, expiryDate, schema, requestData.TechnicalUserDetails, null, requestData.CallbackUrl, companyCredentialDetailsRepository);
@@ -452,7 +451,7 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
             ),
             new CredentialStatus(
                 _settings.StatusListUrl,
-                StatusList)
+                _settings.StatusListType)
         );
         var schema = JsonSerializer.Serialize(schemaData, Options);
         return await HandleCredentialProcessCreation(requestData.HolderBpn, VerifiedCredentialTypeKindId.FRAMEWORK, requestData.UseCaseFrameworkId, result.Expiry, schema, requestData.TechnicalUserDetails, requestData.UseCaseFrameworkVersionId, requestData.CallbackUrl, companyCredentialDetailsRepository);

--- a/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerSettings.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerSettings.cs
@@ -46,6 +46,9 @@ public class IssuerSettings
     public string StatusListUrl { get; set; } = null!;
 
     [Required(AllowEmptyStrings = false)]
+    public string StatusListType { get; set; } = null!;
+
+    [Required(AllowEmptyStrings = false)]
     public string IssuerBpn { get; set; } = null!;
 }
 

--- a/src/issuer/SsiCredentialIssuer.Service/appsettings.json
+++ b/src/issuer/SsiCredentialIssuer.Service/appsettings.json
@@ -74,6 +74,7 @@
     "IssuerDid": "",
     "IssuerBpn": "",
     "StatusListUrl": "",
+    "StatusListType": "",
     "MaxPageSize": 15,
     "EncryptionConfigIndex": 0,
     "EncryptionConfigs": []

--- a/tests/issuer/SsiCredentialIssuer.Service.Tests/BusinessLogic/IssuerBusinessLogicTests.cs
+++ b/tests/issuer/SsiCredentialIssuer.Service.Tests/BusinessLogic/IssuerBusinessLogicTests.cs
@@ -591,7 +591,7 @@ public class IssuerBusinessLogicTests
                 VerifiedCredentialExternalTypeId.TRACEABILITY_CREDENTIAL,
                 CompanyUserId.ToString(),
                 Guid.NewGuid(),
-                Enumerable.Repeat<Guid>(Guid.NewGuid(), 1)));
+                Enumerable.Repeat(Guid.NewGuid(), 1)));
         A.CallTo(() => _companySsiDetailsRepository.AttachAndModifyCompanySsiDetails(CredentialId, A<Action<CompanySsiDetail>?>._, A<Action<CompanySsiDetail>>._!))
             .Invokes((Guid _, Action<CompanySsiDetail>? initialize, Action<CompanySsiDetail> updateFields) =>
             {
@@ -678,15 +678,14 @@ public class IssuerBusinessLogicTests
         var data = new CreateBpnCredentialRequest("https://example.org/holder/BPNL12343546/did.json", Bpnl, null, null);
         var detail = new CompanySsiDetail(CredentialId, _identity.Bpnl, VerifiedCredentialTypeId.BUSINESS_PARTNER_NUMBER, CompanySsiDetailStatusId.ACTIVE, IssuerBpnl, _identity.IdentityId, DateTimeOffset.Now);
 
-        HttpRequestMessage? request = null;
         ConfigureHttpClientFactoryFixture(new HttpResponseMessage
         {
             StatusCode = HttpStatusCode.OK,
             Content = new StringContent(JsonSerializer.Serialize(didDocument))
-        }, requestMessage => request = requestMessage);
+        });
 
         A.CallTo(() => _companySsiDetailsRepository.CreateSsiDetails(_identity.Bpnl, VerifiedCredentialTypeId.BUSINESS_PARTNER_NUMBER, CompanySsiDetailStatusId.ACTIVE, IssuerBpnl, _identity.IdentityId, A<Action<CompanySsiDetail>>._))
-            .Invokes((string bpnl, VerifiedCredentialTypeId verifiedCredentialTypeId, CompanySsiDetailStatusId companySsiDetailStatusId, string issuerBpn, string userId, Action<CompanySsiDetail>? setOptionalFields) => setOptionalFields?.Invoke(detail));
+            .Invokes((string _, VerifiedCredentialTypeId _, CompanySsiDetailStatusId _, string _, string _, Action<CompanySsiDetail>? setOptionalFields) => setOptionalFields?.Invoke(detail));
 
         // Act
         await _sut.CreateBpnCredential(data, CancellationToken.None);
@@ -718,12 +717,11 @@ public class IssuerBusinessLogicTests
         var didId = Guid.NewGuid().ToString();
         var didDocument = new DidDocument(didId);
         var data = new CreateBpnCredentialRequest(holderUrl, Bpnl, null, null);
-        HttpRequestMessage? request = null;
         ConfigureHttpClientFactoryFixture(new HttpResponseMessage
         {
             StatusCode = HttpStatusCode.OK,
             Content = new StringContent(JsonSerializer.Serialize(didDocument))
-        }, requestMessage => request = requestMessage);
+        });
         Task Act() => _sut.CreateBpnCredential(data, CancellationToken.None);
 
         // Act
@@ -754,17 +752,16 @@ public class IssuerBusinessLogicTests
         var data = new CreateMembershipCredentialRequest("https://example.org/holder/BPNL12343546/did.json", Bpnl, "Test", null, null);
         var detail = new CompanySsiDetail(CredentialId, _identity.Bpnl, VerifiedCredentialTypeId.MEMBERSHIP, CompanySsiDetailStatusId.ACTIVE, IssuerBpnl, _identity.IdentityId, DateTimeOffset.Now);
 
-        HttpRequestMessage? request = null;
         A.CallTo(() => _companySsiDetailsRepository.GetCertificateTypes(A<string>._))
             .Returns(Enum.GetValues<VerifiedCredentialTypeId>().ToAsyncEnumerable());
         ConfigureHttpClientFactoryFixture(new HttpResponseMessage
         {
             StatusCode = HttpStatusCode.OK,
             Content = new StringContent(JsonSerializer.Serialize(didDocument))
-        }, requestMessage => request = requestMessage);
+        });
 
         A.CallTo(() => _companySsiDetailsRepository.CreateSsiDetails(_identity.Bpnl, VerifiedCredentialTypeId.MEMBERSHIP, CompanySsiDetailStatusId.ACTIVE, IssuerBpnl, _identity.IdentityId, A<Action<CompanySsiDetail>>._))
-            .Invokes((string bpnl, VerifiedCredentialTypeId verifiedCredentialTypeId, CompanySsiDetailStatusId companySsiDetailStatusId, string issuerBpn, string userId, Action<CompanySsiDetail>? setOptionalFields) => setOptionalFields?.Invoke(detail));
+            .Invokes((string _, VerifiedCredentialTypeId _, CompanySsiDetailStatusId _, string _, string _, Action<CompanySsiDetail>? setOptionalFields) => setOptionalFields?.Invoke(detail));
 
         // Act
         await _sut.CreateMembershipCredential(data, CancellationToken.None);
@@ -925,14 +922,13 @@ public class IssuerBusinessLogicTests
         var now = DateTimeOffset.Now;
         A.CallTo(() => _dateTimeProvider.OffsetNow).Returns(now);
         var data = new CreateFrameworkCredentialRequest("https://example.org/holder/BPNL12343546/did.json", Bpnl, VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK, useCaseId, null, null);
-        HttpRequestMessage? request = null;
         A.CallTo(() => _companySsiDetailsRepository.CheckCredentialTypeIdExistsForExternalTypeDetailVersionId(useCaseId, VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK, Bpnl))
             .Returns((true, "1.0.0", "https://example.org/tempalte", Enumerable.Repeat(VerifiedCredentialExternalTypeId.TRACEABILITY_CREDENTIAL, 1), now.AddDays(5), false));
         ConfigureHttpClientFactoryFixture(new HttpResponseMessage
         {
             StatusCode = HttpStatusCode.OK,
             Content = new StringContent(JsonSerializer.Serialize(didDocument))
-        }, requestMessage => request = requestMessage);
+        });
 
         // Act
         await _sut.CreateFrameworkCredential(data, CancellationToken.None);


### PR DESCRIPTION
## Description

The statuslist type used for the credentials is now configureable

## Why

Since the currently used type for the status list (Statuslist2021) was hardcoded the type used in the credentials for the status list is now configureable to be able to use the BitstringStatusList

## Issue

Refs: #299

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
