### PR TITLE
docs: fix how to contribute link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Link to Github issue.
 
 Please delete options that are not relevant.
 
-- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
+- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
 - [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
 - [ ] I have created and linked IP issues or requested their creation by a committer
 - [ ] I have performed a self-review of my own code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ https://www.eclipse.org/projects/handbook/#resources-commit
 
 ## How To Contribute
 
-For more practical information, please refer to [Contribution details](/docs/technical-documentation/dev-process/How%20to%20contribute.md).
+For more practical information, please refer to [Contribution details](/docs/admin/dev-process/How%20to%20contribute.md).
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See Docker notice files for more information:
 
 ## Contributing
 
-See [Contribution details](/docs/technical-documentation/dev-process/How%20to%20contribute.md).
+See [Contribution details](/docs/admin/dev-process/How%20to%20contribute.md).
 
 ## License
 


### PR DESCRIPTION
## Description

Fix the "How to Contribute" link.

## Why

The existing link is broken.

## Issue

[Issue #483](https://github.com/eclipse-tractusx/portal/issues/483) 

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [X] I have successfully tested my changes locally
