### PR TITLE
feat: enhance use case participant get credential endpoint by supporting filters

### DIFF
--- a/docs/api/issuer-service.yaml
+++ b/docs/api/issuer-service.yaml
@@ -8,7 +8,12 @@ paths:
       tags:
         - 'Org.Eclipse.TractusX.SsiCredentialIssuer.Service, Version=1.2.0.0, Culture=neutral, PublicKeyToken=null'
       summary: Gets all use case frameworks and the participation status of the acting company
-      description: 'Example: GET: api/issuer/useCaseParticipation'
+      description: 'Example: GET: api/issuer/useCaseParticipation<br><h3>Available values:</h3> All, Active, Expired'
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
       responses:
         '200':
           description: OK
@@ -26,6 +31,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '400':
+          description: Bad Request
           content:
             application/json:
               schema:

--- a/docs/api/issuer-service.yaml
+++ b/docs/api/issuer-service.yaml
@@ -288,10 +288,6 @@ paths:
             type: string
             format: uuid
       responses:
-        '200':
-          description: OK
-          content:
-            application/json: { }
         '401':
           description: Unauthorized
           content:
@@ -337,10 +333,6 @@ paths:
             type: string
             format: uuid
       responses:
-        '200':
-          description: OK
-          content:
-            application/json: { }
         '401':
           description: Unauthorized
           content:
@@ -392,10 +384,6 @@ paths:
           schema:
             $ref: '#/components/schemas/ProcessStepTypeId'
       responses:
-        '200':
-          description: OK
-          content:
-            application/json: { }
         '401':
           description: Unauthorized
           content:
@@ -441,13 +429,6 @@ paths:
             type: string
             format: uuid
       responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: string
-                format: uuid
         '401':
           description: Unauthorized
           content:
@@ -460,6 +441,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+                format: uuid
   '/api/revocation/credentials/{credentialId}':
     post:
       tags:
@@ -475,13 +463,6 @@ paths:
             type: string
             format: uuid
       responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: string
-                format: uuid
         '401':
           description: Unauthorized
           content:
@@ -494,6 +475,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+                format: uuid
   '/api/revocation/{processId}/retrigger-step/{processStepTypeId}':
     post:
       tags:
@@ -515,10 +503,6 @@ paths:
           schema:
             $ref: '#/components/schemas/ProcessStepTypeId'
       responses:
-        '200':
-          description: OK
-          content:
-            application/json: { }
         '401':
           description: Unauthorized
           content:
@@ -600,13 +584,6 @@ paths:
             type: string
             format: uuid
       responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: string
-                format: binary
         '401':
           description: Unauthorized
           content:
@@ -619,6 +596,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+                format: binary
         '409':
           description: Conflict
           content:

--- a/src/database/SsiCredentialIssuer.DbAccess/Models/StatusType.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Models/StatusType.cs
@@ -1,0 +1,8 @@
+namespace Org.Eclipse.TractusX.SsiCredentialIssuer.DBAccess.Models;
+
+public enum StatusType
+{
+    Active,
+    Expired,
+    All
+}

--- a/src/database/SsiCredentialIssuer.DbAccess/Models/StatusType.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Models/StatusType.cs
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 namespace Org.Eclipse.TractusX.SsiCredentialIssuer.DBAccess.Models;
 
 public enum StatusType

--- a/src/database/SsiCredentialIssuer.DbAccess/Repositories/ICompanySsiDetailsRepository.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Repositories/ICompanySsiDetailsRepository.cs
@@ -32,8 +32,9 @@ public interface ICompanySsiDetailsRepository
     /// </summary>
     /// <param name="bpnl">Bpnl of the company</param>
     /// <param name="minExpiry">The minimum datetime the expiry date should have</param>
+    /// <param name="statusType">the status type on how the credentials should be filtered</param>
     /// <returns>AsyncEnumerable of UseCaseParticipation</returns>
-    IAsyncEnumerable<UseCaseParticipationData> GetUseCaseParticipationForCompany(string bpnl, DateTimeOffset minExpiry);
+    IAsyncEnumerable<UseCaseParticipationData> GetUseCaseParticipationForCompany(string bpnl, DateTimeOffset minExpiry, StatusType? statusType);
 
     /// <summary>
     /// Gets the company credential details for the given company id

--- a/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IIssuerBusinessLogic.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IIssuerBusinessLogic.cs
@@ -26,7 +26,7 @@ namespace Org.Eclipse.TractusX.SsiCredentialIssuer.Service.BusinessLogic;
 
 public interface IIssuerBusinessLogic
 {
-    IAsyncEnumerable<UseCaseParticipationData> GetUseCaseParticipationAsync();
+    IAsyncEnumerable<UseCaseParticipationData> GetUseCaseParticipationAsync(string? status);
 
     IAsyncEnumerable<CertificateParticipationData> GetSsiCertificatesAsync();
 

--- a/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/BusinessLogic/IssuerBusinessLogic.cs
@@ -82,10 +82,22 @@ public class IssuerBusinessLogic : IIssuerBusinessLogic
     }
 
     /// <inheritdoc />
-    public IAsyncEnumerable<UseCaseParticipationData> GetUseCaseParticipationAsync() =>
-        _repositories
+    public IAsyncEnumerable<UseCaseParticipationData> GetUseCaseParticipationAsync(string? status)
+    {
+        StatusType? statusTypeResult = null;
+        if (!string.IsNullOrEmpty(status))
+        {
+            if (!(Enum.TryParse<StatusType>(status, ignoreCase: true, out var statusType) || !Enum.IsDefined(typeof(StatusType), statusType)))
+            {
+                throw new ArgumentException($"Status value {status} is not valid; please use Active, Expired or All");
+            }
+            statusTypeResult = statusType;
+        }
+
+        return _repositories
             .GetInstance<ICompanySsiDetailsRepository>()
-            .GetUseCaseParticipationForCompany(_identity.Bpnl, _dateTimeProvider.OffsetNow);
+            .GetUseCaseParticipationForCompany(_identity.Bpnl, _dateTimeProvider.OffsetNow, statusTypeResult);
+    }
 
     /// <inheritdoc />
     public IAsyncEnumerable<CertificateParticipationData> GetSsiCertificatesAsync() =>

--- a/src/issuer/SsiCredentialIssuer.Service/Controllers/IssuerController.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/Controllers/IssuerController.cs
@@ -42,9 +42,10 @@ public static class IssuerController
     {
         var issuer = group.MapGroup("/issuer");
 
-        issuer.MapGet("useCaseParticipation", (IIssuerBusinessLogic logic) => logic.GetUseCaseParticipationAsync())
+        issuer.MapGet("useCaseParticipation", (IIssuerBusinessLogic logic,
+                [FromQuery(Name = "status")] string? status) => logic.GetUseCaseParticipationAsync(status))
             .WithSwaggerDescription("Gets all use case frameworks and the participation status of the acting company",
-                "Example: GET: api/issuer/useCaseParticipation")
+                "Example: GET: api/issuer/useCaseParticipation<br><h3>Available values:</h3> All, Active, Expired")
             .RequireAuthorization(r =>
             {
                 r.RequireRole("view_use_case_participation");
@@ -52,6 +53,7 @@ public static class IssuerController
             })
             .WithDefaultResponses()
             .Produces(StatusCodes.Status200OK, typeof(IEnumerable<UseCaseParticipationData>), Constants.JsonContentType)
+            .Produces(StatusCodes.Status400BadRequest, typeof(ErrorResponse), Constants.JsonContentType)
             .Produces(StatusCodes.Status409Conflict, typeof(ErrorResponse), Constants.JsonContentType);
 
         issuer.MapGet("certificates", (IIssuerBusinessLogic logic) => logic.GetSsiCertificatesAsync())

--- a/tests/database/SsiCredentialIssuer.DbAccess.Tests/CompanySsiDetailsRepositoryTests.cs
+++ b/tests/database/SsiCredentialIssuer.DbAccess.Tests/CompanySsiDetailsRepositoryTests.cs
@@ -50,14 +50,16 @@ public class CompanySsiDetailsRepositoryTests
 
     #region GetDetailsForCompany
 
-    [Fact]
-    public async Task GetDetailsForCompany_WithValidData_ReturnsExpected()
+    [Theory]
+    [InlineData(null)]
+    [InlineData(StatusType.All)]
+    public async Task GetDetailsForCompany_WithValidData_And_StatusType_ReturnsExpected(StatusType? statusType)
     {
         // Arrange
         var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetUseCaseParticipationForCompany(ValidBpnl, DateTimeOffset.MinValue).ToListAsync();
+        var result = await sut.GetUseCaseParticipationForCompany(ValidBpnl, DateTimeOffset.MinValue, statusType).ToListAsync();
 
         // Assert
         result.Should().HaveCount(10);
@@ -85,7 +87,7 @@ public class CompanySsiDetailsRepositoryTests
         var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetUseCaseParticipationForCompany(ValidBpnl, dt).ToListAsync();
+        var result = await sut.GetUseCaseParticipationForCompany(ValidBpnl, dt, null).ToListAsync();
 
         // Assert
         result.Should().HaveCount(10);
@@ -103,6 +105,56 @@ public class CompanySsiDetailsRepositoryTests
             x => x.ExternalDetailData.Version == "1.0" && x.SsiDetailData.Count() == 1,
             x => x.ExternalDetailData.Version == "2.0" && !x.SsiDetailData.Any(),
             x => x.ExternalDetailData.Version == "3.0" && !x.SsiDetailData.Any());
+    }
+
+    [Fact]
+    public async Task GetAllExternalTypeDetailDataWithValidData_WithValidData_and_StatusType_Active_ReturnsExpected()
+    {
+        // Arrange
+        var sut = await CreateSut();
+
+        //Act
+
+        var result = await sut.GetUseCaseParticipationForCompany(ValidBpnl, DateTimeOffset.UtcNow, StatusType.Active).ToListAsync();
+
+        // Assert
+        result.Should().HaveCount(10);
+        result.SelectMany(x => x.VerifiedCredentials)
+            .Select(x => x.ExternalDetailData)
+                .Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task GetAllExternalTypeDetailDataWithValidData_and_StatusType_All_ReturnsExpected()
+    {
+        // Arrange
+        var sut = await CreateSut();
+
+        //Act
+
+        var result = await sut.GetUseCaseParticipationForCompany(ValidBpnl, DateTimeOffset.UtcNow, StatusType.All).ToListAsync();
+
+        // Assert
+        result.Should().HaveCount(10);
+        result.SelectMany(x => x.VerifiedCredentials)
+            .Select(x => x.ExternalDetailData)
+                .Should().HaveCount(11);
+    }
+
+    [Fact]
+    public async Task GetAllExternalTypeDetailDataWithValidData_WithValidData_and_StatusType_Expired_ReturnsExpected()
+    {
+        // Arrange
+        var sut = await CreateSut();
+        //Act
+
+        var result = await sut.GetUseCaseParticipationForCompany(ValidBpnl, DateTimeOffset.UtcNow, StatusType.Expired).ToListAsync();
+
+        // Assert
+        result.Should().HaveCount(10);
+        result.SelectMany(x => x.VerifiedCredentials)
+            .Select(x => x.ExternalDetailData)
+                .Should().HaveCount(10);
     }
 
     #endregion

--- a/tests/issuer/SsiCredentialIssuer.Service.Tests/BusinessLogic/IssuerBusinessLogicTests.cs
+++ b/tests/issuer/SsiCredentialIssuer.Service.Tests/BusinessLogic/IssuerBusinessLogicTests.cs
@@ -123,7 +123,7 @@ public class IssuerBusinessLogicTests
         Setup_GetUseCaseParticipationAsync();
 
         // Act
-        var result = await _sut.GetUseCaseParticipationAsync().ToListAsync();
+        var result = await _sut.GetUseCaseParticipationAsync(null).ToListAsync();
 
         // Assert
         result.Should().HaveCount(5);
@@ -161,6 +161,93 @@ public class IssuerBusinessLogicTests
 
         // Assert
         result.Should().HaveCount(5);
+    }
+
+    [Fact]
+    public async Task GetUseCaseParticipationAsync_WithValidStatus_ReturnsExpectedResults()
+    {
+        // Arrange
+        var status = "Active";
+        var now = DateTimeOffset.Now;
+        var verifiedCredentials = _fixture.Build<CompanySsiExternalTypeDetailData>()
+            .With(x => x.SsiDetailData, _fixture.CreateMany<CompanySsiDetailData>(1))
+            .CreateMany(5);
+        var expectedData = new List<UseCaseParticipationData>
+        {
+            new UseCaseParticipationData("Test", "Test", VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK, verifiedCredentials)
+        }.ToAsyncEnumerable();
+
+        A.CallTo(() => _dateTimeProvider.OffsetNow).Returns(now);
+        A.CallTo(() => _companySsiDetailsRepository.GetUseCaseParticipationForCompany(_identity.Bpnl, now, StatusType.Active))
+            .Returns(expectedData);
+
+        // Act
+        var result = await _sut.GetUseCaseParticipationAsync(status).ToListAsync();
+
+        // Assert
+        result.Should().BeEquivalentTo(expectedData.ToEnumerable());
+    }
+
+    [Fact]
+    public async Task GetUseCaseParticipationAsync_WithInvalidStatus_ThrowsArgumentException()
+    {
+        // Arrange
+        var status = "InvalidStatus";
+
+        // Act
+        Func<Task> act = async () => await _sut.GetUseCaseParticipationAsync(status).ToListAsync();
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("Status value InvalidStatus is not valid; please use Active, Expired or All");
+    }
+
+    [Fact]
+    public async Task GetUseCaseParticipationAsync_WithNullStatus_ReturnsExpectedResults()
+    {
+        // Arrange
+        var now = DateTimeOffset.Now;
+        var verifiedCredentials = _fixture.Build<CompanySsiExternalTypeDetailData>()
+            .With(x => x.SsiDetailData, _fixture.CreateMany<CompanySsiDetailData>(1))
+            .CreateMany(5);
+        var expectedData = new List<UseCaseParticipationData>
+        {
+            new UseCaseParticipationData("Test", "Test", VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK, verifiedCredentials)
+        }.ToAsyncEnumerable();
+
+        A.CallTo(() => _dateTimeProvider.OffsetNow).Returns(now);
+        A.CallTo(() => _companySsiDetailsRepository.GetUseCaseParticipationForCompany(_identity.Bpnl, now, null))
+            .Returns(expectedData);
+
+        // Act
+        var result = await _sut.GetUseCaseParticipationAsync(null).ToListAsync();
+
+        // Assert
+        result.Should().BeEquivalentTo(expectedData.ToEnumerable());
+    }
+
+    [Fact]
+    public async Task GetUseCaseParticipationAsync_WithAllStatus_ReturnsExpectedResults()
+    {
+        // Arrange
+        var now = DateTimeOffset.Now;
+        var verifiedCredentials = _fixture.Build<CompanySsiExternalTypeDetailData>()
+            .With(x => x.SsiDetailData, _fixture.CreateMany<CompanySsiDetailData>(1))
+            .CreateMany(5);
+        var expectedData = new List<UseCaseParticipationData>
+        {
+            new UseCaseParticipationData("Test", "Test", VerifiedCredentialTypeId.TRACEABILITY_FRAMEWORK, verifiedCredentials)
+        }.ToAsyncEnumerable();
+
+        A.CallTo(() => _dateTimeProvider.OffsetNow).Returns(now);
+        A.CallTo(() => _companySsiDetailsRepository.GetUseCaseParticipationForCompany(_identity.Bpnl, now, StatusType.All))
+            .Returns(expectedData);
+
+        // Act
+        var result = await _sut.GetUseCaseParticipationAsync("All").ToListAsync();
+
+        // Assert
+        result.Should().BeEquivalentTo(expectedData.ToEnumerable());
     }
 
     #endregion
@@ -1079,7 +1166,7 @@ public class IssuerBusinessLogicTests
         var verifiedCredentials = _fixture.Build<CompanySsiExternalTypeDetailData>()
             .With(x => x.SsiDetailData, _fixture.CreateMany<CompanySsiDetailData>(1))
             .CreateMany(5);
-        A.CallTo(() => _companySsiDetailsRepository.GetUseCaseParticipationForCompany(Bpnl, A<DateTimeOffset>._))
+        A.CallTo(() => _companySsiDetailsRepository.GetUseCaseParticipationForCompany(Bpnl, A<DateTimeOffset>._, null))
             .Returns(_fixture.Build<UseCaseParticipationData>().With(x => x.VerifiedCredentials, verifiedCredentials).CreateMany(5).ToAsyncEnumerable());
     }
 


### PR DESCRIPTION
### Description

The purpose of this feature is to enhance the functionality of the existing GET /api/issuer/useCaseParticipation endpoint in the Issuer Component. The enhancement involves the ability to filter the returned list of use case participations by the status of the credentials (Active, Expired, or All).

### Why

Instead of always returning all use case credentials it gives the customer the power of retrieving it by status.

Issue

NA

### Checklist

Please delete options that are not relevant.


- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added copyright and license headers, footers (for .md files) or files (for images)
