### PR TITLE
fix(processWorker): add missing registrations

### DIFF
--- a/src/credentials/SsiCredentialIssuer.Expiry.App/Program.cs
+++ b/src/credentials/SsiCredentialIssuer.Expiry.App/Program.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.Hosting;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Logging;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Token;
 using Org.Eclipse.TractusX.SsiCredentialIssuer.DBAccess;
+using Org.Eclipse.TractusX.SsiCredentialIssuer.Entities.Auditing.DependencyInjection;
 using Org.Eclipse.TractusX.SsiCredentialIssuer.Expiry.App;
 using Org.Eclipse.TractusX.SsiCredentialIssuer.Expiry.App.DependencyInjection;
 using Org.Eclipse.TractusX.SsiCredentialIssuer.Portal.Service.DependencyInjection;

--- a/src/database/SsiCredentialIssuer.DbAccess/IssuerRepositoriesStartupServiceExtensions.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/IssuerRepositoriesStartupServiceExtensions.cs
@@ -20,6 +20,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess;
 using Org.Eclipse.TractusX.SsiCredentialIssuer.Entities;
 using Org.Eclipse.TractusX.SsiCredentialIssuer.Entities.Auditing.DependencyInjection;
 
@@ -30,6 +31,7 @@ public static class IssuerRepositoriesStartupServiceExtensions
     public static IServiceCollection AddIssuerRepositories(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddScoped<IIssuerRepositories, IssuerRepositories>()
+            .AddScoped<IRepositories, IssuerRepositories>()
             .AddDbAuditing()
             .AddDbContext<IssuerDbContext>(o => o
                     .UseNpgsql(configuration.GetConnectionString("IssuerDb")))

--- a/src/processes/Processes.ProcessIdentity/ProcessIdentityDataDetermination.cs
+++ b/src/processes/Processes.ProcessIdentity/ProcessIdentityDataDetermination.cs
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -17,24 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Validation;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.ProcessIdentity;
-using Org.Eclipse.TractusX.SsiCredentialIssuer.Entities.Auditing.Identity;
 
 namespace Org.Eclipse.TractusX.SsiCredentialIssuer.Processes.ProcessIdentity;
 
-public static class ServiceCollectionExtensions
+public class ProcessIdentityDataDetermination : IProcessIdentityDataDetermination
 {
-    public static IServiceCollection AddProcessIdentity(this IServiceCollection services, IConfigurationSection section)
-    {
-        services.AddOptions<ProcessExecutionServiceSettings>()
-            .Bind(section)
-            .EnvironmentalValidation(section);
-
-        return services
-            .AddScoped<IProcessIdentityDataDetermination, ProcessIdentityDataDetermination>()
-            .AddScoped<IIdentityIdService, ProcessIdentityIdService>();
-    }
+    public Task GetIdentityData() => Task.CompletedTask;
 }

--- a/src/processes/Processes.ProcessIdentity/Processes.ProcessIdentity.csproj
+++ b/src/processes/Processes.ProcessIdentity/Processes.ProcessIdentity.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.1" />
     <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="3.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.ProcessIdentity" Version="2.17.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/processes/Processes.Worker/Processes.Worker.csproj
+++ b/src/processes/Processes.Worker/Processes.Worker.csproj
@@ -36,6 +36,7 @@
       <ProjectReference Include="..\..\externalservices\Callback.Service\Callback.Service.csproj" />
       <ProjectReference Include="..\..\externalservices\Portal.Service\Portal.Service.csproj" />
       <ProjectReference Include="..\CredentialProcess.Worker\CredentialProcess.Worker.csproj" />
+      <ProjectReference Include="..\Processes.ProcessIdentity\Processes.ProcessIdentity.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/processes/Processes.Worker/Program.cs
+++ b/src/processes/Processes.Worker/Program.cs
@@ -27,6 +27,7 @@ using Org.Eclipse.TractusX.SsiCredentialIssuer.CredentialProcess.Worker.Dependen
 using Org.Eclipse.TractusX.SsiCredentialIssuer.DBAccess;
 using Org.Eclipse.TractusX.SsiCredentialIssuer.Entities.Enums;
 using Org.Eclipse.TractusX.SsiCredentialIssuer.Portal.Service.DependencyInjection;
+using Org.Eclipse.TractusX.SsiCredentialIssuer.Processes.ProcessIdentity;
 using Org.Eclipse.TractusX.SsiCredentialIssuer.Wallet.Service.DependencyInjection;
 using Serilog;
 
@@ -41,6 +42,7 @@ try
             services
                 .AddTransient<ITokenService, TokenService>()
                 .AddIssuerRepositories(hostContext.Configuration)
+                .AddProcessIdentity(hostContext.Configuration.GetSection("Processes"))
                 .AddProcessExecutionService<ProcessTypeId, ProcessStepTypeId>(hostContext.Configuration.GetSection("Processes"))
                 .AddPortalService(hostContext.Configuration.GetSection("Portal"))
                 .AddCallbackService(hostContext.Configuration.GetSection("Callback"))


### PR DESCRIPTION
## Description

Add missing registrations for process worker

## Why

The process worker doesn't start due to missing registrations

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
