### PR TITLE
fix(errorHandling): adjust general error handler

### DIFF
--- a/src/credentials/SsiCredentialIssuer.Expiry.App/SsiCredentialIssuer.Expiry.App.csproj
+++ b/src/credentials/SsiCredentialIssuer.Expiry.App/SsiCredentialIssuer.Expiry.App.csproj
@@ -42,9 +42,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="3.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="3.7.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="3.7.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="3.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/database/SsiCredentialIssuer.DbAccess/SsiCredentialIssuer.DbAccess.csproj
+++ b/src/database/SsiCredentialIssuer.DbAccess/SsiCredentialIssuer.DbAccess.csproj
@@ -30,9 +30,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.1" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="3.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess" Version="3.7.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="3.7.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="3.7.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/database/SsiCredentialIssuer.Entities/SsiCredentialIssuer.Entities.csproj
+++ b/src/database/SsiCredentialIssuer.Entities/SsiCredentialIssuer.Entities.csproj
@@ -33,11 +33,11 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Linq" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Concrete" Version="3.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="3.7.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess" Version="3.7.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="3.7.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Linq" Version="3.7.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Concrete" Version="3.7.0" />
   </ItemGroup>
   <ItemGroup>
     <SonarQubeSetting Include="sonar.coverage.exclusions">

--- a/src/database/SsiCredentialIssuer.Migrations/SsiCredentialIssuer.Migrations.csproj
+++ b/src/database/SsiCredentialIssuer.Migrations/SsiCredentialIssuer.Migrations.csproj
@@ -49,8 +49,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="3.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="3.7.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="3.7.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.0" />
   </ItemGroup>
 

--- a/src/externalservices/Callback.Service/Callback.Service.csproj
+++ b/src/externalservices/Callback.Service/Callback.Service.csproj
@@ -29,8 +29,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.1" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="3.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="3.7.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="3.7.0" />
   </ItemGroup>
 
 </Project>

--- a/src/externalservices/Portal.Service/Portal.Service.csproj
+++ b/src/externalservices/Portal.Service/Portal.Service.csproj
@@ -29,8 +29,8 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.1" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="3.3.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="3.3.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="3.7.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="3.7.0" />
     </ItemGroup>
 
 </Project>

--- a/src/externalservices/Wallet.Service/Wallet.Service.csproj
+++ b/src/externalservices/Wallet.Service/Wallet.Service.csproj
@@ -32,8 +32,8 @@
   <ItemGroup>
     <PackageReference Include="JsonSchema.Net" Version="7.3.1" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.1" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="3.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="3.7.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="3.7.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="Schemas\BpnCredential.schema.json">

--- a/src/issuer/SsiCredentialIssuer.Service/Program.cs
+++ b/src/issuer/SsiCredentialIssuer.Service/Program.cs
@@ -20,6 +20,7 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models.Extensions;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Token;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Web;
@@ -39,6 +40,7 @@ await WebApplicationBuildRunner
     .BuildAndRunWebApplicationAsync<Program>(args, "issuer", version, ".Issuer", builder =>
         {
             builder.Services
+                .AddTransient<GeneralHttpExceptionMiddleware>()
                 .AddTransient<IClaimsTransformation, KeycloakClaimsTransformation>()
                 .AddTransient<IAuthorizationHandler, MandatoryIdentityClaimHandler>()
                 .AddTransient<ITokenService, TokenService>()
@@ -63,6 +65,7 @@ await WebApplicationBuildRunner
         },
     (app, _) =>
     {
+        app.UseMiddleware<GeneralHttpExceptionMiddleware>();
         app.MapGroup("/api")
             .WithOpenApi()
             .MapIssuerApi()

--- a/src/issuer/SsiCredentialIssuer.Service/SsiCredentialIssuer.Service.csproj
+++ b/src/issuer/SsiCredentialIssuer.Service/SsiCredentialIssuer.Service.csproj
@@ -44,9 +44,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="3.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="3.7.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library" Version="3.7.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="3.7.0" />
     <PackageReference Include="PasswordGenerator" Version="2.1.0" />
     <PackageReference Include="System.Json" Version="4.8.0" />
   </ItemGroup>

--- a/src/processes/CredentialProcess.Library/CredentialProcess.Library.csproj
+++ b/src/processes/CredentialProcess.Library/CredentialProcess.Library.csproj
@@ -35,7 +35,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library" Version="3.3.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library" Version="3.7.0" />
     </ItemGroup>
 
 </Project>

--- a/src/processes/CredentialProcess.Worker/CredentialProcess.Worker.csproj
+++ b/src/processes/CredentialProcess.Worker/CredentialProcess.Worker.csproj
@@ -32,7 +32,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Worker.Library" Version="2.17.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Worker.Library" Version="3.7.0" />
     </ItemGroup>
 
 </Project>

--- a/src/processes/Processes.ProcessIdentity/Processes.ProcessIdentity.csproj
+++ b/src/processes/Processes.ProcessIdentity/Processes.ProcessIdentity.csproj
@@ -34,7 +34,8 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.1" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="3.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="3.7.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.ProcessIdentity" Version="3.7.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/processes/Processes.Worker/Processes.Worker.csproj
+++ b/src/processes/Processes.Worker/Processes.Worker.csproj
@@ -40,9 +40,9 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="3.3.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library" Version="3.3.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="3.3.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="3.7.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library" Version="3.7.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="3.7.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/externalservices/Wallet.Service.Tests/Wallet.Service.Tests.csproj
+++ b/tests/externalservices/Wallet.Service.Tests/Wallet.Service.Tests.csproj
@@ -35,7 +35,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web" Version="3.3.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.1.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">


### PR DESCRIPTION
## Description

fixing the current error handling

## Why

after the net 9 upgrade the general error handling was broken and always returned a 500

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
