### PR TITLE
fix: added missing ids to verified credential external types table

### DIFF
--- a/src/database/SsiCredentialIssuer.Migrations/Seeder/Data/verified_credential_type_assigned_external_types.json
+++ b/src/database/SsiCredentialIssuer.Migrations/Seeder/Data/verified_credential_type_assigned_external_types.json
@@ -24,6 +24,10 @@
     "verified_credential_type_id": 6
   },
   {
+    "verified_credential_external_type_id": 7,
+    "verified_credential_type_id": 7
+  },
+  {
     "verified_credential_external_type_id": 8,
     "verified_credential_type_id": 8
   },
@@ -34,6 +38,10 @@
   {
     "verified_credential_external_type_id": 10,
     "verified_credential_type_id": 10
+  },
+  {
+    "verified_credential_external_type_id": 11,
+    "verified_credential_type_id": 11
   },
   {
     "verified_credential_external_type_id": 12,


### PR DESCRIPTION
Description

Added two missing ids(BUSINESS_PARTNER_NUMBER and FRAMEWORK_AGREEMENT) into assigned external credential type table. 

Why

The Expiry App  service was failing due to missing ids which were not mapped into the verified_credential_type_assigned_external_types table. This was leading to an exception during the iteration of the credentials. 

## Issue

N/a

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
