### PR TITLE
feat: Enhanced the notification message when the credential is expired

### DIFF
--- a/src/credentials/SsiCredentialIssuer.Expiry.App/ExpiryCheckService.cs
+++ b/src/credentials/SsiCredentialIssuer.Expiry.App/ExpiryCheckService.cs
@@ -170,18 +170,19 @@ public class ExpiryCheckService
 
         var content = JsonSerializer.Serialize(new
         {
-            Type = data.VerifiedCredentialExternalTypeId,
+            AssignedExternalCredentialType = data.VerifiedCredentialExternalTypeId?.GetEnumValue(),
             ExpiryDate = data.ExpiryDate?.ToString("O") ?? throw new ConflictException("Expiry Date must be set here"),
             Version = data.DetailVersion,
             CredentialId = data.Id,
-            ExpiryCheckTypeId = newExpiryCheckTypeId
+            CredentialType = data.verifiedCredentialTypeId.ToString(),
+            ExpiryCheckTypeId = newExpiryCheckTypeId.ToString()
         }, Options);
 
         if (Guid.TryParse(data.RequesterId, out var requesterId))
         {
             await portalService.AddNotification(content, requesterId, NotificationTypeId.CREDENTIAL_EXPIRY,
                 cancellationToken).ConfigureAwait(ConfigureAwaitOptions.None);
-            var typeValue = data.VerifiedCredentialExternalTypeId.GetEnumValue() ??
+            var typeValue = data.VerifiedCredentialExternalTypeId?.GetEnumValue() ??
                             throw new UnexpectedConditionException(
                                 $"VerifiedCredentialType {data.VerifiedCredentialExternalTypeId} does not exists");
             var mailParameters = new MailParameter[]

--- a/src/database/SsiCredentialIssuer.DbAccess/Models/CredentialExpiryData.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Models/CredentialExpiryData.cs
@@ -29,7 +29,8 @@ public record CredentialExpiryData(
     string? DetailVersion,
     string Bpnl,
     CompanySsiDetailStatusId CompanySsiDetailStatusId,
-    VerifiedCredentialExternalTypeId VerifiedCredentialExternalTypeId,
+    VerifiedCredentialTypeId verifiedCredentialTypeId,
+    VerifiedCredentialExternalTypeId? VerifiedCredentialExternalTypeId,
     CredentialScheduleData ScheduleData);
 
 public record CredentialScheduleData(

--- a/src/database/SsiCredentialIssuer.DbAccess/Repositories/CompanySsiDetailsRepository.cs
+++ b/src/database/SsiCredentialIssuer.DbAccess/Repositories/CompanySsiDetailsRepository.cs
@@ -305,6 +305,7 @@ public class CompanySsiDetailsRepository(IssuerDbContext context)
                 x.Details.VerifiedCredentialExternalTypeDetailVersion!.Version,
                 x.Details.Bpnl,
                 x.Details.CompanySsiDetailStatusId,
+                x.Details.VerifiedCredentialTypeId,
                 x.Details.VerifiedCredentialType!.VerifiedCredentialTypeAssignedExternalType!.VerifiedCredentialExternalTypeId,
                 new CredentialScheduleData(
                     x.IsVcToDelete,

--- a/tests/credentials/SsiCredentialIssuer.Expiry.App.Tests/ExpiryCheckServiceTests.cs
+++ b/tests/credentials/SsiCredentialIssuer.Expiry.App.Tests/ExpiryCheckServiceTests.cs
@@ -21,7 +21,9 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Extensions;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.Enums;
 using Org.Eclipse.TractusX.SsiCredentialIssuer.DBAccess;
@@ -202,7 +204,7 @@ public class ExpiryCheckServiceTests
         A.CallTo(() => _issuerRepositories.SaveAsync()).MustHaveHappenedOnceExactly();
         A.CallTo(() => _portalService.TriggerMail("CredentialExpiry", creatorUserId, A<IEnumerable<MailParameter>>._, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
 
-        credentialNotification.GetLastValue().Should().ContainAll("MembershipCredential", "MEMBERSHIP");
+        credentialNotification.GetLastValue().Should().ContainAll(VerifiedCredentialExternalTypeId.MEMBERSHIP_CREDENTIAL.GetEnumValue(), VerifiedCredentialTypeId.MEMBERSHIP.GetEnumValue());
         ssiDetail.ExpiryCheckTypeId.Should().Be(expiryCheckTypeId);
     }
 }


### PR DESCRIPTION
## Description

Enhanced the notification message for expired credentials

## Why

The current expired credential notification payload does not include enough usable information to specify which exact credential has expired



## Issue

[Link to Github issue.](https://github.com/eclipse-tractusx/ssi-credential-issuer/issues/353)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
