### PR TITLE
fix: change image pull secret indentation for jobs

### DIFF
--- a/charts/ssi-credential-issuer/Chart.yaml
+++ b/charts/ssi-credential-issuer/Chart.yaml
@@ -20,8 +20,8 @@
 apiVersion: v2
 name: ssi-credential-issuer
 type: application
-version: 1.3.1
-appVersion: 1.3.1
+version: 1.3.0
+appVersion: 1.3.0
 description: Helm chart for SSI Credential Issuer
 home: https://github.com/eclipse-tractusx/ssi-credential-issuer
 dependencies:

--- a/charts/ssi-credential-issuer/Chart.yaml
+++ b/charts/ssi-credential-issuer/Chart.yaml
@@ -20,8 +20,8 @@
 apiVersion: v2
 name: ssi-credential-issuer
 type: application
-version: 1.3.0
-appVersion: 1.3.0
+version: 1.3.1
+appVersion: 1.3.1
 description: Helm chart for SSI Credential Issuer
 home: https://github.com/eclipse-tractusx/ssi-credential-issuer
 dependencies:

--- a/charts/ssi-credential-issuer/templates/cronjob-expiry-app.yaml
+++ b/charts/ssi-credential-issuer/templates/cronjob-expiry-app.yaml
@@ -36,7 +36,7 @@ spec:
           restartPolicy: OnFailure
           {{- with .Values.credentialExpiry.image.pullSecrets }}
           imagePullSecrets:
-            {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           containers:
           - name: {{ include "issuer.fullname" . }}-{{ .Values.credentialExpiry.name }}

--- a/charts/ssi-credential-issuer/templates/cronjob-expiry-app.yaml
+++ b/charts/ssi-credential-issuer/templates/cronjob-expiry-app.yaml
@@ -36,7 +36,7 @@ spec:
           restartPolicy: OnFailure
           {{- with .Values.credentialExpiry.image.pullSecrets }}
           imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 10 }}
           {{- end }}
           containers:
           - name: {{ include "issuer.fullname" . }}-{{ .Values.credentialExpiry.name }}

--- a/charts/ssi-credential-issuer/templates/cronjob-issuer-processes.yaml
+++ b/charts/ssi-credential-issuer/templates/cronjob-issuer-processes.yaml
@@ -36,7 +36,7 @@ spec:
           restartPolicy: OnFailure
           {{- with .Values.processesworker.image.pullSecrets }}
           imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 10 }}
           {{- end }}
           containers:
           - name: {{ include "issuer.fullname" . }}-{{ .Values.processesworker.name }}

--- a/charts/ssi-credential-issuer/templates/cronjob-issuer-processes.yaml
+++ b/charts/ssi-credential-issuer/templates/cronjob-issuer-processes.yaml
@@ -36,7 +36,7 @@ spec:
           restartPolicy: OnFailure
           {{- with .Values.processesworker.image.pullSecrets }}
           imagePullSecrets:
-            {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           containers:
           - name: {{ include "issuer.fullname" . }}-{{ .Values.processesworker.name }}


### PR DESCRIPTION
## Description & Why

For the imagePullSecrets in the cronjob type template, the indentation needs to be two more spaces due to the fact that it has "one more father" than the Deployments or Jobs templates.

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
