### PR TITLE
Chore/enhance the logging of data deletion job

### DIFF
--- a/src/credentials/SsiCredentialIssuer.Expiry.App/ExpiryCheckService.cs
+++ b/src/credentials/SsiCredentialIssuer.Expiry.App/ExpiryCheckService.cs
@@ -88,10 +88,12 @@ public class ExpiryCheckService
 
                 var credentials = outerLoopRepositories.GetInstance<ICompanySsiDetailsRepository>()
                     .GetExpiryData(now, inactiveVcsToDelete, expiredVcsToDelete);
+                _logger.LogInformation("Total number of credentials to be processed for details are {Count}", await credentials.CountAsync(stoppingToken).ConfigureAwait(false));
                 await foreach (var credential in credentials.WithCancellation(stoppingToken).ConfigureAwait(false))
                 {
                     await ProcessCredentials(credential, companySsiDetailsRepository, repositories, portalService, processStepRepository, stoppingToken).ConfigureAwait(ConfigureAwaitOptions.None);
                 }
+                _logger.LogInformation("Credential details process completed successfully");
             }
             catch (Exception ex)
             {
@@ -109,21 +111,30 @@ public class ExpiryCheckService
         IProcessStepRepository<ProcessTypeId, ProcessStepTypeId> processStepRepository,
         CancellationToken cancellationToken)
     {
-        if (data.ScheduleData.IsVcToDelete)
+        try
         {
-            companySsiDetailsRepository.RemoveSsiDetail(data.Id, data.Bpnl, data.RequesterId);
-        }
-        else if (data.ScheduleData.IsVcToDecline)
-        {
-            HandleDecline(data.Id, companySsiDetailsRepository, processStepRepository);
-        }
-        else
-        {
-            await HandleNotification(data, companySsiDetailsRepository, portalService, cancellationToken).ConfigureAwait(false);
-        }
+            if (data.ScheduleData.IsVcToDelete)
+            {
+                companySsiDetailsRepository.RemoveSsiDetail(data.Id, data.Bpnl, data.RequesterId);
+            }
+            else if (data.ScheduleData.IsVcToDecline)
+            {
+                HandleDecline(data.Id, companySsiDetailsRepository, processStepRepository);
+            }
+            else
+            {
+                await HandleNotification(data, companySsiDetailsRepository, portalService, cancellationToken).ConfigureAwait(false);
+            }
 
-        // Saving here to make sure the each credential is handled by there own 
-        await repositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
+            // Saving here to make sure the each credential is handled by there own 
+            await repositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
+
+        }
+        catch (Exception ex)
+        {
+            var message = $"An error occurred while processing credential details '{ex.Message}' for ID '{data.Id}'";
+            throw new InvalidOperationException(message, ex);
+        }
     }
 
     private static void HandleDecline(

--- a/src/credentials/SsiCredentialIssuer.Expiry.App/ExpiryCheckService.cs
+++ b/src/credentials/SsiCredentialIssuer.Expiry.App/ExpiryCheckService.cs
@@ -132,7 +132,7 @@ public class ExpiryCheckService
         }
         catch (Exception ex)
         {
-            var message = $"An error occurred while processing credential details '{ex.Message}' for ID '{data.Id}'";
+            var message = $"Failed to process credential with ID '{data.Id}': {ex.Message}";
             throw new InvalidOperationException(message, ex);
         }
     }


### PR DESCRIPTION
## Description

- Log added in the the `ExpiryCheckService` in case of error

## Why

-  We can get the error log in the console, so we don't have to check a database for errors

## Issue
https://github.com/eclipse-tractusx/ssi-credential-issuer/issues/403


## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added copyright and license headers, footers (for .md files) or files (for images)
