### PR TITLE
chore: logs added in case if error in expiry checks

### DIFF
--- a/src/credentials/SsiCredentialIssuer.Expiry.App/ExpiryCheckService.cs
+++ b/src/credentials/SsiCredentialIssuer.Expiry.App/ExpiryCheckService.cs
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/credentials/SsiCredentialIssuer.Expiry.App/ExpiryCheckService.cs
+++ b/src/credentials/SsiCredentialIssuer.Expiry.App/ExpiryCheckService.cs
@@ -88,10 +88,13 @@ public class ExpiryCheckService
 
                 var credentials = outerLoopRepositories.GetInstance<ICompanySsiDetailsRepository>()
                     .GetExpiryData(now, inactiveVcsToDelete, expiredVcsToDelete);
+                _logger.LogInformation("Total number of credentials to be processed for details are {Count}", await credentials.CountAsync(stoppingToken).ConfigureAwait(false));
                 await foreach (var credential in credentials.WithCancellation(stoppingToken).ConfigureAwait(false))
                 {
                     await ProcessCredentials(credential, companySsiDetailsRepository, repositories, portalService, processStepRepository, stoppingToken).ConfigureAwait(ConfigureAwaitOptions.None);
                 }
+                _logger.LogInformation("Credential details process completed successfully");
+
             }
             catch (Exception ex)
             {
@@ -109,21 +112,30 @@ public class ExpiryCheckService
         IProcessStepRepository<ProcessTypeId, ProcessStepTypeId> processStepRepository,
         CancellationToken cancellationToken)
     {
-        if (data.ScheduleData.IsVcToDelete)
+        try
         {
-            companySsiDetailsRepository.RemoveSsiDetail(data.Id, data.Bpnl, data.RequesterId);
-        }
-        else if (data.ScheduleData.IsVcToDecline)
-        {
-            HandleDecline(data.Id, companySsiDetailsRepository, processStepRepository);
-        }
-        else
-        {
-            await HandleNotification(data, companySsiDetailsRepository, portalService, cancellationToken).ConfigureAwait(false);
-        }
+            if (data.ScheduleData.IsVcToDelete)
+            {
+                companySsiDetailsRepository.RemoveSsiDetail(data.Id, data.Bpnl, data.RequesterId);
+            }
+            else if (data.ScheduleData.IsVcToDecline)
+            {
+                HandleDecline(data.Id, companySsiDetailsRepository, processStepRepository);
+            }
+            else
+            {
+                await HandleNotification(data, companySsiDetailsRepository, portalService, cancellationToken)
+                    .ConfigureAwait(false);
+            }
 
-        // Saving here to make sure the each credential is handled by there own 
-        await repositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
+            // Saving here to make sure the each credential is handled by there own 
+            await repositories.SaveAsync().ConfigureAwait(ConfigureAwaitOptions.None);
+        }
+        catch (Exception ex)
+        {
+            var message = $"Failed to process credential with ID '{data.Id}': {ex.Message}";
+            throw new InvalidOperationException(message, ex);
+        }
     }
 
     private static void HandleDecline(

--- a/tests/credentials/SsiCredentialIssuer.Expiry.App.Tests/ExpiryCheckServiceTests.cs
+++ b/tests/credentials/SsiCredentialIssuer.Expiry.App.Tests/ExpiryCheckServiceTests.cs
@@ -1,9 +1,26 @@
-using Fare;
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.OpenApi.Extensions;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Processes.Library.DBAccess;
@@ -16,7 +33,6 @@ using Org.Eclipse.TractusX.SsiCredentialIssuer.Entities.Enums;
 using Org.Eclipse.TractusX.SsiCredentialIssuer.Expiry.App.DependencyInjection;
 using Org.Eclipse.TractusX.SsiCredentialIssuer.Portal.Service.Models;
 using Org.Eclipse.TractusX.SsiCredentialIssuer.Portal.Service.Services;
-using System.Runtime.CompilerServices;
 
 namespace Org.Eclipse.TractusX.SsiCredentialIssuer.Expiry.App.Tests;
 


### PR DESCRIPTION
## Description

- Log added in the the `ExpiryCheckService` in case of error

## Why

-  We can get the error log in the console, so we don't have to check a database for errors

## Issue
https://github.com/eclipse-tractusx/ssi-credential-issuer/issues/403


## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added copyright and license headers, footers (for .md files) or files (for images)
