### PR TITLE
build(1.4.1-rc.2): change bitnami image repository

### DIFF
--- a/charts/ssi-credential-issuer/Chart.yaml
+++ b/charts/ssi-credential-issuer/Chart.yaml
@@ -20,8 +20,8 @@
 apiVersion: v2
 name: ssi-credential-issuer
 type: application
-version: 1.4.1-rc.1
-appVersion: 1.4.1-rc.1
+version: 1.4.1-rc.2
+appVersion: 1.4.1-rc.2
 description: Helm chart for SSI Credential Issuer
 home: https://github.com/eclipse-tractusx/ssi-credential-issuer
 dependencies:

--- a/charts/ssi-credential-issuer/README.md
+++ b/charts/ssi-credential-issuer/README.md
@@ -31,7 +31,7 @@ To use the helm chart as a dependency:
 dependencies:
   - name: ssi-credential-issuer
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 1.4.1-rc.1
+    version: 1.4.1-rc.2
 ```
 
 ## Requirements
@@ -120,7 +120,7 @@ dependencies:
 | dbConnection.schema | string | `"issuer"` |  |
 | dbConnection.sslMode | string | `"Disable"` |  |
 | postgresql.enabled | bool | `true` | PostgreSQL chart configuration; default configurations: host: "issuer-postgresql-primary", port: 5432; Switch to enable or disable the PostgreSQL helm chart. |
-| postgresql.image | object | `{"tag":"15-debian-12"}` | Setting image tag to major to get latest minor updates |
+| postgresql.image | object | `{"registry":"docker.io","repository":"bitnamilegacy/postgresql","tag":"15-debian-12"}` | Setting image tag to major to get latest minor updates |
 | postgresql.commonLabels."app.kubernetes.io/version" | string | `"15"` |  |
 | postgresql.auth.username | string | `"issuer"` | Non-root username. |
 | postgresql.auth.database | string | `"issuer"` | Database name. |

--- a/charts/ssi-credential-issuer/values.yaml
+++ b/charts/ssi-credential-issuer/values.yaml
@@ -188,6 +188,8 @@ postgresql:
   enabled: true
   # -- Setting image tag to major to get latest minor updates
   image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
     tag: "15-debian-12"
   commonLabels:
     app.kubernetes.io/version: "15"


### PR DESCRIPTION
## Description

- change bitnami image path to legacy repository

## Why

- Bitnami now requires a paid subscription to use their images.

## Issue

Closes: #408 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
