### PR TITLE
ci(reissuance): fix bugs in reissuance script

### DIFF
--- a/.github/workflows/reissue-expiring-credentials.yaml
+++ b/.github/workflows/reissue-expiring-credentials.yaml
@@ -63,10 +63,7 @@ on:
 
 jobs:
   reissue_expiring_credentials:
-    runs-on:
-      group: apps-stage
-      labels: apps
-    environment: ReissueExpiringCredentials
+    runs-on: ubuntu-latest
 
     steps:
     - name: Check out repository

--- a/environments/reissue_expiring_credentials/reissue_expiring_credentials.py
+++ b/environments/reissue_expiring_credentials/reissue_expiring_credentials.py
@@ -331,7 +331,6 @@ def get_auth_token(auth_base_url: str, auth_path: str, client_id: str, client_se
     else:
         payload = f"client_id={client_id}&grant_type=client_credentials&client_secret={client_secret}"
 
-    logging.debug(f"Getting token from {urljoin(auth_base_url, auth_path)}")
     response: Response = requests.post(urljoin(auth_base_url, auth_path), headers=headers, data=payload)
     if response.status_code != 200:
         raise requests.HTTPError(f"Failed to get access token: {response.status_code} {response.text}")

--- a/environments/reissue_expiring_credentials/reissue_expiring_credentials.py
+++ b/environments/reissue_expiring_credentials/reissue_expiring_credentials.py
@@ -331,6 +331,7 @@ def get_auth_token(auth_base_url: str, auth_path: str, client_id: str, client_se
     else:
         payload = f"client_id={client_id}&grant_type=client_credentials&client_secret={client_secret}"
 
+    logging.debug(f"Getting token from {urljoin(auth_base_url, auth_path)}")
     response: Response = requests.post(urljoin(auth_base_url, auth_path), headers=headers, data=payload)
     if response.status_code != 200:
         raise requests.HTTPError(f"Failed to get access token: {response.status_code} {response.text}")
@@ -537,7 +538,7 @@ def revoke_credential(auth_url: str, client_id: str, client_secret: str, issuer_
 
 def parse_cli_args() -> tuple[Namespace, list[str]]:
     parser = argparse.ArgumentParser(description="Reissue expiring credentials")
-    parser.add_argument("--stage", required=True, choices=["integration", "beta", "svc"], help="Environment stage")
+    parser.add_argument("--stage", required=True, choices=["int"], help="Environment stage")
     parser.add_argument("--start_date", type=date.fromisoformat, required=True,
                         help="yyyy-mm-dd - Credentials expiring on or after this date and on or before end_date will be reissued.")
     parser.add_argument("--end_date", type=date.fromisoformat, required=True,

--- a/environments/reissue_expiring_credentials/reissue_expiring_credentials.py
+++ b/environments/reissue_expiring_credentials/reissue_expiring_credentials.py
@@ -106,7 +106,7 @@ def fetch_active_credentials(auth_base_url: str, client_id: str, client_secret: 
         AUTHORIZATION: BEARER_TOKEN.format(issuer_service_auth_token),
     }
 
-    current_page = 1
+    current_page = 0
     total_num_pages = 1
     credential_list_acc: list = []
 
@@ -128,7 +128,7 @@ def fetch_active_credentials(auth_base_url: str, client_id: str, client_secret: 
                 f"Issuer service returned 200, but the response contained invalid JSON for page={current_page}: {response.text}")
             raise jsonDecodeError
         # Determine total number of pages
-        if current_page == 1:
+        if current_page == 0:
             try:
                 total_num_pages = response_json["meta"]["totalPages"]
             except JSONDecodeError as jsonDecodeError:


### PR DESCRIPTION
## Description

- pagination starts at 0
- use public runner for execution

## Why

Job didn't run and runs were missing some company credentials.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1666
https://github.com/eclipse-tractusx/portal-backend/issues/1464

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
