### PR TITLE
fix: token clock skew config set in the correct format (#162)

### DIFF
--- a/src/issuer/SsiCredentialIssuer.Service/appsettings.json
+++ b/src/issuer/SsiCredentialIssuer.Service/appsettings.json
@@ -40,7 +40,7 @@
       "ValidAudience": "",
       "ValidateAudience": true,
       "ValidateLifetime": true,
-      "ClockSkew": "00:00:05"
+      "ClockSkew": "00:01:00"
     }
   },
   "Portal": {

--- a/src/issuer/SsiCredentialIssuer.Service/appsettings.json
+++ b/src/issuer/SsiCredentialIssuer.Service/appsettings.json
@@ -40,7 +40,7 @@
       "ValidAudience": "",
       "ValidateAudience": true,
       "ValidateLifetime": true,
-      "ClockSkew": 600000
+      "ClockSkew": "00:00:05"
     }
   },
   "Portal": {


### PR DESCRIPTION
## Description

Fixes the ClockSkew configuration value in appsettings.json to use the correct TimeSpan string format.

## Why

Please include an explanation of why this change is necessary as well as relevant motivation and context. List any dependencies that are required for this change.

The current configuration sets ClockSkew as an integer:

``` json
"ClockSkew": 60000
```

When .NET binds a plain integer to a TimeSpan property, it interprets the value as days, not milliseconds. This results in a clock skew of approximately 164 years instead of the intended 1 minute.

## Issue

[452](https://github.com/eclipse-tractusx/ssi-credential-issuer/issues/452)

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added copyright and license headers, footers (for .md files) or files (for images)
