### PR TITLE
fix(build): prevent dotnet roll forward to latest major version

### DIFF
--- a/src/issuer/SsiCredentialIssuer.Service/SsiCredentialIssuer.Service.csproj
+++ b/src/issuer/SsiCredentialIssuer.Service/SsiCredentialIssuer.Service.csproj
@@ -35,7 +35,7 @@
   <Target Name="openapi" AfterTargets="Build">
     <Message Text="generating openapi v$(Version)" Importance="high" />
     <Exec Command="dotnet tool restore" />
-    <Exec Command="dotnet tool run swagger tofile --yaml --output ../../../docs/api/issuer-service.yaml $(OutputPath)$(AssemblyName).dll v$(Version)" EnvironmentVariables="DOTNET_ROLL_FORWARD=LatestMajor;SKIP_CONFIGURATION_VALIDATION=true" />
+    <Exec Command="dotnet tool run swagger tofile --yaml --output ../../../docs/api/issuer-service.yaml $(OutputPath)$(AssemblyName).dll v$(Version)" EnvironmentVariables="DOTNET_ROLL_FORWARD=LatestMinor;SKIP_CONFIGURATION_VALIDATION=true" />
   </Target>
 
   <ItemGroup>

--- a/src/issuer/SsiCredentialIssuer.Service/SsiCredentialIssuer.Service.csproj
+++ b/src/issuer/SsiCredentialIssuer.Service/SsiCredentialIssuer.Service.csproj
@@ -1,5 +1,6 @@
 <!--
 - Copyright (c) 2024 Contributors to the Eclipse Foundation
+- Copyright (c) 2026 Technovative Solutions
 -
 - See the NOTICE file(s) distributed with this work for additional
 - information regarding copyright ownership.


### PR DESCRIPTION
## Description

A command is updated in the `.csproj` file to take the latest minor version of dotnet so that we don't get any unexpected build errors due to incompatible versions.

## Why

Build fails due to this command: `DOTNET_ROLL_FORWARD=LatestMajor` in the csproj file that takes the latest major version of the dotnet runtime found in the machine while building the project. This PR fixes this issue.

## Issue

Closes #467 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/ssi-credential-issuer/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
